### PR TITLE
Add and document DVector and DMatrix types to clarify RDD[Vector] usage, additional vector comments and cleanups.

### DIFF
--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/CheckedIterator.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/CheckedIterator.scala
@@ -17,9 +17,23 @@
 
 package org.apache.spark.mllib.optimization.tfocs
 
-/**
- * Evaluation mode.
- * @param f Whether to compute the function value.
- * @param g Whether to compute the function gradient.
- */
-case class Mode(f: Boolean, g: Boolean)
+class CheckedIterator[A](self: Iterator[A]) {
+
+  def checkedZip[B](that: Iterator[B]): Iterator[(A, B)] =
+    new Iterator[(A, B)] {
+      def hasNext: Boolean = (self.hasNext, that.hasNext) match {
+        case (true, true) => true
+        case (false, false) => false
+        case _ => throw new IllegalArgumentException("Can only checkedZip Iterators with the " +
+          "same number of elements")
+      }
+      def next(): (A, B) = (self.next(), that.next())
+    }
+}
+
+object CheckedIterator {
+
+  implicit def iteratorToCheckedIterator[T](iterator: Iterator[T]): CheckedIterator[T] = {
+    new CheckedIterator(iterator)
+  }
+}

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/CheckedIteratorFunctions.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/CheckedIteratorFunctions.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.mllib.optimization.tfocs
 
-class CheckedIterator[A](self: Iterator[A]) {
+class CheckedIteratorFunctions[A](self: Iterator[A]) {
 
   def checkedZip[B](that: Iterator[B]): Iterator[(A, B)] =
     new Iterator[(A, B)] {
@@ -31,9 +31,8 @@ class CheckedIterator[A](self: Iterator[A]) {
     }
 }
 
-object CheckedIterator {
+object CheckedIteratorFunctions {
 
-  implicit def iteratorToCheckedIterator[T](iterator: Iterator[T]): CheckedIterator[T] = {
-    new CheckedIterator(iterator)
-  }
+  implicit def iteratorToCheckedIterator[T](iterator: Iterator[T]): CheckedIteratorFunctions[T] =
+    new CheckedIteratorFunctions(iterator)
 }

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/DVectorFunctions.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/DVectorFunctions.scala
@@ -19,7 +19,6 @@ package org.apache.spark.mllib.optimization.tfocs
 
 import org.apache.spark.mllib.linalg.{ BLAS, DenseVector, Vector }
 import org.apache.spark.mllib.optimization.tfocs.VectorSpace._
-import org.apache.spark.rdd.RDD
 
 /** Functional helpers for DVector objects representing distributed one dimensional vectors. */
 private[tfocs] class DVectorFunctions(self: DVector) {
@@ -58,6 +57,6 @@ private[tfocs] class DVectorFunctions(self: DVector) {
 
 private[tfocs] object DVectorFunctions {
 
-  implicit def RDDToDVectorFunctions(dVector: DVector): DVectorFunctions =
+  implicit def DVectorToDVectorFunctions(dVector: DVector): DVectorFunctions =
     new DVectorFunctions(dVector)
 }

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/LinearFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/LinearFunction.scala
@@ -19,7 +19,7 @@ package org.apache.spark.mllib.optimization.tfocs
 
 import org.apache.spark.mllib.linalg.BLAS
 import org.apache.spark.mllib.linalg.{ DenseVector, Vector, Vectors }
-import org.apache.spark.mllib.optimization.tfocs.CheckedIterator._
+import org.apache.spark.mllib.optimization.tfocs.CheckedIteratorFunctions._
 import org.apache.spark.rdd.RDD
 
 /**

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/LinearFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/LinearFunction.scala
@@ -21,7 +21,6 @@ import org.apache.spark.mllib.linalg.BLAS
 import org.apache.spark.mllib.linalg.{ DenseVector, Vector, Vectors }
 import org.apache.spark.mllib.optimization.tfocs.CheckedIteratorFunctions._
 import org.apache.spark.mllib.optimization.tfocs.VectorSpace._
-import org.apache.spark.rdd.RDD
 
 /**
  * A trait for linear functions supporting application of a function and of its transpose.

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/LinearFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/LinearFunction.scala
@@ -19,10 +19,14 @@ package org.apache.spark.mllib.optimization.tfocs
 
 import org.apache.spark.mllib.linalg.BLAS
 import org.apache.spark.mllib.linalg.{ DenseVector, Vector, Vectors }
+import org.apache.spark.mllib.optimization.tfocs.CheckedIterator._
 import org.apache.spark.rdd.RDD
 
 /**
  * Trait for linear functions.
+ *
+ * @tparam X Type representing a linear function input vector.
+ * @tparam Y Type representing a linear function output vector.
  */
 trait LinearFunction[X, Y] {
   /**
@@ -105,8 +109,8 @@ class TransposeProductVectorRDDVector(@transient private val matrix: RDD[Vector]
 
   override def apply(x: RDD[Vector]): Vector = {
     matrix.zipPartitions(x)({ (matrixPartition, xPartition) =>
-      Iterator.single(matrixPartition.zip(xPartition.next.toArray.toIterator)
-        .aggregate(Vectors.zeros(n))(
+      Iterator.single(
+        matrixPartition.checkedZip(xPartition.next.toArray.toIterator).aggregate(Vectors.zeros(n))(
           seqop = (sum, row) => {
             BLAS.axpy(row._2, row._1, sum)
             sum

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunction.scala
@@ -21,12 +21,15 @@ import org.apache.spark.mllib.linalg.{ DenseVector, Vector, Vectors }
 
 /**
  * Trait for prox-capable functions.
+ *
+ * @tparam X Type representing a vector on which to evaluate the function.
  */
 trait ProxCapableFunction[X] {
   /**
-   * Evaluates this function at x with smoothing parameter t.
+   * Evaluates this function at x with smoothing parameter t, returning the minimum value and
+   * minimizing vector.
    */
-  def apply(x: X, t: Double, mode: Mode): Value[Double, X]
+  def apply(x: X, t: Double, mode: Mode): Value[X]
 
   /**
    * Evaluates this function at x.
@@ -35,14 +38,14 @@ trait ProxCapableFunction[X] {
 }
 
 /** A function that always returns zero. */
-class ZeroProxVector extends ProxCapableFunction[Vector] {
-  override def apply(x: Vector, t: Double, mode: Mode): Value[Double, Vector] =
+class ProxZeroVector extends ProxCapableFunction[Vector] {
+  override def apply(x: Vector, t: Double, mode: Mode): Value[Vector] =
     Value(Some(0.0), Some(x))
 }
 
 /** A function that returns the L1 norm. */
-class L1ProxVector(scale: Double) extends ProxCapableFunction[Vector] {
-  override def apply(x: Vector, t: Double, mode: Mode): Value[Double, Vector] = {
+class ProxL1Vector(scale: Double) extends ProxCapableFunction[Vector] {
+  override def apply(x: Vector, t: Double, mode: Mode): Value[Vector] = {
     val shrinkage = scale * t
     val g = shrinkage match {
       case 0.0 => x

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunction.scala
@@ -69,6 +69,8 @@ class ProjRPlusVector extends ProxCapableFunction[Vector] {
 
     Value(Some(0.0), g)
   }
+
+  override def apply(x: Vector): Double = if (x.toArray.min < 0.0) Double.PositiveInfinity else 0.0
 }
 
 /**
@@ -90,4 +92,7 @@ class ProjBoxVector(l: Vector, u: Vector) extends ProxCapableFunction[Vector] {
 
     Value(Some(0.0), g)
   }
+
+  override def apply(x: Vector): Double = if (x.toArray.zip(limits).exists(y =>
+    y._1 > y._2._2 || y._1 < y._2._1)) Double.PositiveInfinity else 0.0
 }

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunction.scala
@@ -56,3 +56,38 @@ class ProxL1Vector(scale: Double) extends ProxCapableFunction[Vector] {
     Value(f, Some(g))
   }
 }
+
+/** A function that projects onto the positive orthant. */
+class ProjRPlusVector extends ProxCapableFunction[Vector] {
+  override def apply(x: Vector, t: Double, mode: Mode): Value[Vector] = {
+
+    val g = if (mode.g) {
+      Some(new DenseVector(x.toArray.map(math.max(_, 0.0))))
+    } else {
+      None
+    }
+
+    Value(Some(0.0), g)
+  }
+}
+
+/**
+ * A function that projects onto a simple box defined by upper and lower limits on each vector
+ * element.
+ */
+class ProjBoxVector(l: Vector, u: Vector) extends ProxCapableFunction[Vector] {
+
+  val limits = l.toArray.zip(u.toArray)
+
+  override def apply(x: Vector, t: Double, mode: Mode): Value[Vector] = {
+
+    val g = if (mode.g) {
+      Some(new DenseVector(x.toArray.zip(limits).map(y =>
+        math.min(y._2._2, math.max(y._1, y._2._1)))))
+    } else {
+      None
+    }
+
+    Value(Some(0.0), g)
+  }
+}

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunction.scala
@@ -94,5 +94,5 @@ class ProjBoxVector(l: Vector, u: Vector) extends ProxCapableFunction[Vector] {
   }
 
   override def apply(x: Vector): Double = if (x.toArray.zip(limits).exists(y =>
-    y._1 > y._2._2 || y._1 < y._2._1)) Double.PositiveInfinity else 0.0
+    y._1 > y._2._2 || y._1 < y._2._1)) { Double.PositiveInfinity } else { 0.0 }
 }

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunction.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.mllib.optimization.tfocs
 
 import org.apache.spark.mllib.linalg.{ DenseVector, Vectors, Vector }
-import org.apache.spark.mllib.linalg.BLAS
 import org.apache.spark.mllib.optimization.tfocs.VectorRDDFunctions._
 import org.apache.spark.rdd.RDD
 

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunction.scala
@@ -19,7 +19,7 @@ package org.apache.spark.mllib.optimization.tfocs
 
 import org.apache.spark.mllib.linalg.{ DenseVector, Vectors, Vector }
 import org.apache.spark.mllib.linalg.BLAS
-import org.apache.spark.mllib.optimization.tfocs.CheckedIterator._
+import org.apache.spark.mllib.optimization.tfocs.VectorRDDFunctions._
 import org.apache.spark.rdd.RDD
 
 /**
@@ -59,12 +59,10 @@ class SmoothQuadRDDVector(x0: RDD[Vector]) extends SmoothFunction[RDD[Vector]] {
   x0.cache()
 
   override def apply(x: RDD[Vector], mode: Mode): Value[RDD[Vector]] = {
-    val g = x.zip(x0).map(y =>
-      new DenseVector(y._1.toArray.toIterator.checkedZip(y._2.toArray.toIterator).map(z =>
-        z._1 - z._2).toArray): Vector)
+    val g = x.diff(x0)
     if (mode.f && mode.g) g.cache()
     val f = if (mode.f) {
-      Some(g.treeAggregate(0.0)((sum, x) => sum + Math.pow(Vectors.norm(x, 2), 2), _ + _) / 2.0)
+      Some(g.treeAggregate(0.0)((sum, y) => sum + Math.pow(Vectors.norm(y, 2), 2), _ + _) / 2.0)
     } else {
       None
     }
@@ -72,3 +70,70 @@ class SmoothQuadRDDVector(x0: RDD[Vector]) extends SmoothFunction[RDD[Vector]] {
   }
 }
 
+/**
+ * The huber loss function applied to RDD[Vector] vectors.
+ *
+ * @param x0 The vector against which loss should be computed.
+ * @param tau The huber loss parameter.
+ */
+class SmoothHuberRDDVector(x0: RDD[Vector], tau: Double)
+    extends SmoothFunction[RDD[Vector]] with Serializable {
+
+  x0.cache()
+
+  override def apply(x: RDD[Vector], mode: Mode): Value[RDD[Vector]] = {
+
+    val diff = x.diff(x0)
+    if (mode.f && mode.g) diff.cache()
+
+    val f = if (mode.f) {
+      Some(diff.mapElements(y =>
+        if (math.abs(y) <= tau) 0.5 * y * y / tau else math.abs(y) - tau / 2.0).sum)
+    } else {
+      None
+    }
+
+    val g = if (mode.g) {
+      Some(diff.mapElements(y => y / math.max(math.abs(y), tau)))
+    } else {
+      None
+    }
+
+    Value(f, g)
+  }
+}
+
+/**
+ * The log likelihood logistic loss function applied to RDD[Vector] vectors.
+ *
+ * @param y The observed values.
+ * @param mu The variable values.
+ */
+class SmoothLogLLogisticRDDVector(y: RDD[Vector])
+    extends SmoothFunction[RDD[Vector]] with Serializable {
+
+  y.cache()
+
+  override def apply(mu: RDD[Vector], mode: Mode): Value[RDD[Vector]] = {
+
+    val f = if (mode.f) {
+      Some(y.zipElements(mu, (y_i, mu_i) => {
+        val yFactor = if (mu_i > 0.0) y_i - 1.0 else if (mu_i < 0.0) y_i else 0.0
+        yFactor * mu_i - math.log1p(math.exp(-math.abs(mu_i)))
+      }).sum)
+    } else {
+      None
+    }
+
+    val g = if (mode.g) {
+      Some(y.zipElements(mu, (y_i, mu_i) => {
+        val muFactor = if (mu_i > 0.0) 1.0 else math.exp(mu_i)
+        y_i - muFactor / (1.0 + math.exp(-math.abs(mu_i)))
+      }))
+    } else {
+      None
+    }
+
+    Value(f, g)
+  }
+}

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunction.scala
@@ -17,10 +17,9 @@
 
 package org.apache.spark.mllib.optimization.tfocs
 
-import org.apache.spark.mllib.linalg.{ DenseVector, Vectors, Vector }
+import org.apache.spark.mllib.linalg.{ Vector, Vectors }
 import org.apache.spark.mllib.optimization.tfocs.DVectorFunctions._
 import org.apache.spark.mllib.optimization.tfocs.VectorSpace._
-import org.apache.spark.rdd.RDD
 
 /**
  * A trait for smooth functions, with support for evaluating the function and computing its

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunction.scala
@@ -23,32 +23,50 @@ import org.apache.spark.mllib.optimization.tfocs.VectorSpace._
 import org.apache.spark.rdd.RDD
 
 /**
- * Trait for smooth functions.
+ * A trait for smooth functions, with support for evaluating the function and computing its
+ * gradient.
  *
  * @tparam X Type representing a vector on which to evaluate the function.
  */
 trait SmoothFunction[X] {
   /**
-   * Evaluates this function at x and returns the function value and its gradient based on the mode
+   * Evaluates this function at x and returns the function value and gradient, depending on the mode
    * specified.
+   *
+   * @param x The vector on which to evaluate the function.
+   * @param mode The computation mode. If mode.f is true, the function value is returned. If mode.g
+   *        is true, the function gradient is returned.
+   * @return A Value containing the function value and/or gradient, depending on the 'mode'
+   *         parameter. The function value is contained in value.f, while the gradient is contained
+   *         in value.g.
    */
   def apply(x: X, mode: Mode): Value[X]
 
   /**
-   * Evaluates this function at x.
+   * Evaluates the function on vector x.
    */
   def apply(x: X): Double = apply(x, Mode(f = true, g = false)).f.get
 }
 
-/** The squared error function applied to DVectors, with a constant factor of 0.5. */
+/**
+ * The squared error function applied to a DVector, with a constant factor of 0.5.
+ *
+ * @param x0 The base vector against which the squared error difference is computed.
+ */
 class SmoothQuadDVector(x0: DVector) extends SmoothFunction[DVector] {
 
   x0.cache()
 
   override def apply(x: DVector, mode: Mode): Value[DVector] = {
+
+    // Compute the squared error gradient (just the difference between vectors).
     val g = x.diff(x0)
+
+    // If both f and g are requested then g will be read twice, so cache it.
     if (mode.f && mode.g) g.cache()
+
     val f = if (mode.f) {
+      // Compute the squared error.
       Some(g.treeAggregate(0.0)((sum, y) => sum + Math.pow(Vectors.norm(y, 2), 2), _ + _) / 2.0)
     } else {
       None
@@ -58,7 +76,7 @@ class SmoothQuadDVector(x0: DVector) extends SmoothFunction[DVector] {
 }
 
 /**
- * The huber loss function applied to DVectors.
+ * The huber loss function applied to a DVector.
  *
  * @param x0 The vector against which loss should be computed.
  * @param tau The huber loss parameter.
@@ -71,12 +89,20 @@ class SmoothHuberDVector(x0: DVector, tau: Double)
   override def apply(x: DVector, mode: Mode): Value[DVector] = {
 
     val diff = x.diff(x0)
+
+    // If both f and g are requested then diff will be read twice, so cache it.
     if (mode.f && mode.g) diff.cache()
 
     val f = if (mode.f) {
       Some(diff.aggregateElements(0.0)(
-        seqOp = (sum, y) => {
-          val huberValue = if (math.abs(y) <= tau) 0.5 * y * y / tau else math.abs(y) - tau / 2.0
+        seqOp = (sum, diff_i) => {
+          // Find the huber loss, corresponding to the adjusted l2 loss when the magnitude is <= tau
+          // and to the adjusted l1 loss when the magnitude is > tau.
+          val huberValue = if (math.abs(diff_i) <= tau) {
+            0.5 * diff_i * diff_i / tau
+          } else {
+            math.abs(diff_i) - tau / 2.0
+          }
           sum + huberValue
         },
         combOp = _ + _))
@@ -85,7 +111,8 @@ class SmoothHuberDVector(x0: DVector, tau: Double)
     }
 
     val g = if (mode.g) {
-      Some(diff.mapElements(y => y / math.max(math.abs(y), tau)))
+      // Compute the huber loss gradient elementwise.
+      Some(diff.mapElements(diff_i => diff_i / math.max(math.abs(diff_i), tau)))
     } else {
       None
     }
@@ -95,13 +122,12 @@ class SmoothHuberDVector(x0: DVector, tau: Double)
 }
 
 /**
- * The log likelihood logistic loss function applied to DVectors.
+ * The log likelihood logistic loss function applied to a DVector.
  *
- * @param y The observed values.
+ * @param y The observed values, labeled as binary 0/1.
  * @param mu The variable values.
  */
-class SmoothLogLLogisticDVector(y: DVector)
-    extends SmoothFunction[DVector] with Serializable {
+class SmoothLogLLogisticDVector(y: DVector) extends SmoothFunction[DVector] with Serializable {
 
   y.cache()
 
@@ -109,16 +135,26 @@ class SmoothLogLLogisticDVector(y: DVector)
 
     val f = if (mode.f) {
       Some(y.zip(mu).treeAggregate(0.0)(
-        seqOp = (sum, vectors) => {
-          if (vectors._1.size != vectors._2.size) {
-            throw new IllegalArgumentException("Can only zip Vectors with the same number of " +
-              "elements")
+        seqOp = (_, _) match {
+          case (sum, (yPart, muPart)) => {
+
+            // Check that the y and mu partitions are the same size.
+            if (yPart.size != muPart.size) {
+              throw new IllegalArgumentException("Can only zip Vectors with the same number of " +
+                "elements")
+            }
+
+            yPart.toArray.zip(muPart.toArray).aggregate(0.0)(
+              seqop = (sum, elements) => {
+
+                // Compute the loss contribution for each y_i, mu_i pair, and add it to the
+                // aggregated sum.
+                val (y_i, mu_i) = elements
+                val yFactor = if (mu_i > 0.0) y_i - 1.0 else if (mu_i < 0.0) y_i else 0.0
+                sum + yFactor * mu_i - math.log1p(math.exp(-math.abs(mu_i)))
+              },
+              combop = _ + _)
           }
-          vectors._1.toArray.zip(vectors._2.toArray).map(elements => {
-            val (y_i, mu_i) = elements
-            val yFactor = if (mu_i > 0.0) y_i - 1.0 else if (mu_i < 0.0) y_i else 0.0
-            yFactor * mu_i - math.log1p(math.exp(-math.abs(mu_i)))
-          }).sum + sum
         },
         combOp = _ + _))
     } else {
@@ -127,6 +163,7 @@ class SmoothLogLLogisticDVector(y: DVector)
 
     val g = if (mode.g) {
       Some(y.zipElements(mu, (y_i, mu_i) => {
+        // Compute the log logistic loss gradient elementwise.
         val muFactor = if (mu_i > 0.0) 1.0 else math.exp(mu_i)
         y_i - muFactor / (1.0 + math.exp(-math.abs(mu_i)))
       }))

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunction.scala
@@ -40,19 +40,6 @@ trait SmoothFunction[X] {
   def apply(x: X): Double = apply(x, Mode(f = true, g = false)).f.get
 }
 
-/** The squared error function applied to RDD[Double] vectors, with a constant factor of 0.5. */
-class SmoothQuadRDDDouble(x0: RDD[Double]) extends SmoothFunction[RDD[Double]] {
-
-  x0.cache()
-
-  override def apply(x: RDD[Double], mode: Mode): Value[RDD[Double]] = {
-    val g = x.zip(x0).map(y => y._1 - y._2)
-    if (mode.f && mode.g) g.cache()
-    val f = if (mode.f) Some(g.treeAggregate(0.0)((sum, y) => sum + y * y, _ + _) / 2.0) else None
-    Value(f, Some(g))
-  }
-}
-
 /** The squared error function applied to DVectors, with a constant factor of 0.5. */
 class SmoothQuadDVector(x0: DVector) extends SmoothFunction[DVector] {
 

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunction.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunction.scala
@@ -18,7 +18,8 @@
 package org.apache.spark.mllib.optimization.tfocs
 
 import org.apache.spark.mllib.linalg.{ DenseVector, Vectors, Vector }
-import org.apache.spark.mllib.optimization.tfocs.VectorRDDFunctions._
+import org.apache.spark.mllib.optimization.tfocs.DVectorFunctions._
+import org.apache.spark.mllib.optimization.tfocs.VectorSpace._
 import org.apache.spark.rdd.RDD
 
 /**
@@ -52,12 +53,12 @@ class SmoothQuadRDDDouble(x0: RDD[Double]) extends SmoothFunction[RDD[Double]] {
   }
 }
 
-/** The squared error function applied to RDD[Vector] vectors, with a constant factor of 0.5. */
-class SmoothQuadRDDVector(x0: RDD[Vector]) extends SmoothFunction[RDD[Vector]] {
+/** The squared error function applied to DVectors, with a constant factor of 0.5. */
+class SmoothQuadDVector(x0: DVector) extends SmoothFunction[DVector] {
 
   x0.cache()
 
-  override def apply(x: RDD[Vector], mode: Mode): Value[RDD[Vector]] = {
+  override def apply(x: DVector, mode: Mode): Value[DVector] = {
     val g = x.diff(x0)
     if (mode.f && mode.g) g.cache()
     val f = if (mode.f) {
@@ -70,17 +71,17 @@ class SmoothQuadRDDVector(x0: RDD[Vector]) extends SmoothFunction[RDD[Vector]] {
 }
 
 /**
- * The huber loss function applied to RDD[Vector] vectors.
+ * The huber loss function applied to DVectors.
  *
  * @param x0 The vector against which loss should be computed.
  * @param tau The huber loss parameter.
  */
-class SmoothHuberRDDVector(x0: RDD[Vector], tau: Double)
-    extends SmoothFunction[RDD[Vector]] with Serializable {
+class SmoothHuberDVector(x0: DVector, tau: Double)
+    extends SmoothFunction[DVector] with Serializable {
 
   x0.cache()
 
-  override def apply(x: RDD[Vector], mode: Mode): Value[RDD[Vector]] = {
+  override def apply(x: DVector, mode: Mode): Value[DVector] = {
 
     val diff = x.diff(x0)
     if (mode.f && mode.g) diff.cache()
@@ -107,17 +108,17 @@ class SmoothHuberRDDVector(x0: RDD[Vector], tau: Double)
 }
 
 /**
- * The log likelihood logistic loss function applied to RDD[Vector] vectors.
+ * The log likelihood logistic loss function applied to DVectors.
  *
  * @param y The observed values.
  * @param mu The variable values.
  */
-class SmoothLogLLogisticRDDVector(y: RDD[Vector])
-    extends SmoothFunction[RDD[Vector]] with Serializable {
+class SmoothLogLLogisticDVector(y: DVector)
+    extends SmoothFunction[DVector] with Serializable {
 
   y.cache()
 
-  override def apply(mu: RDD[Vector], mode: Mode): Value[RDD[Vector]] = {
+  override def apply(mu: DVector, mode: Mode): Value[DVector] = {
 
     val f = if (mode.f) {
       Some(y.zip(mu).treeAggregate(0.0)(

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/Value.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/Value.scala
@@ -19,7 +19,9 @@ package org.apache.spark.mllib.optimization.tfocs
 
 /**
  * Evaluation result.
- * @param f optional function value
- * @param g optional gradient value
+ *
+ * @param f An optional function value.
+ * @param g An optional function gradient value.
+ * @tparam X Type representing a vector.
  */
-case class Value[X, Y](f: Option[X], g: Option[Y])
+case class Value[X](f: Option[Double], g: Option[X])

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/VectorRDDFunctions.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/VectorRDDFunctions.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.optimization.tfocs
+
+import org.apache.spark.mllib.linalg.{ BLAS, DenseVector, Vector }
+import org.apache.spark.rdd.RDD
+
+class VectorRDDFunctions(self: RDD[Vector]) {
+
+  def mapElements(f: Double => Double): RDD[Vector] =
+    self.map(x => new DenseVector(x.toArray.map(f)))
+
+  def zipElements(other: RDD[Vector], f: (Double, Double) => Double): RDD[Vector] =
+    self.zip(other).map({ x =>
+      if (x._1.size != x._2.size) {
+        throw new IllegalArgumentException("Can only zipElements RDD[Vector]s with the same " +
+          "number of elements")
+      }
+      new DenseVector(x._1.toArray.zip(x._2.toArray).map(y => f(y._1, y._2))): Vector
+    })
+
+  def diff(other: RDD[Vector]): RDD[Vector] =
+    self.zip(other).map({ x =>
+      val ret = x._1.copy
+      BLAS.axpy(-1.0, x._2, ret)
+      ret
+    })
+
+  def sum: Double = self.map(_.toArray.sum).sum
+}
+
+object VectorRDDFunctions {
+
+  implicit def RDDToVectorRDDFunctions(rdd: RDD[Vector]): VectorRDDFunctions =
+    new VectorRDDFunctions(rdd)
+}

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpace.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpace.scala
@@ -23,17 +23,19 @@ import org.apache.spark.rdd.RDD
 
 /**
  * Trait for a vector space.
+ *
+ * @tparam X Type representing a vector.
  */
-trait VectorSpace[V] {
+trait VectorSpace[X] {
 
   /** Linear combination of two vectors. */
-  def combine(alpha: Double, a: V, beta: Double, b: V): V
+  def combine(alpha: Double, a: X, beta: Double, b: X): X
 
   /** Inner product of two vectors. */
-  def dot(a: V, b: V): Double
+  def dot(a: X, b: X): Double
 
   /** Cache a vector. */
-  def cache(a: V): Unit = {}
+  def cache(a: X): Unit = {}
 }
 
 object VectorSpace {

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpace.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpace.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.mllib.optimization.tfocs
 
-import org.apache.spark.mllib.linalg.{ DenseVector, Vector }
+import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.mllib.linalg.BLAS
 import org.apache.spark.rdd.RDD
 

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpace.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpace.scala
@@ -74,18 +74,6 @@ object VectorSpace {
     override def dot(a: Vector, b: Vector): Double = BLAS.dot(a, b)
   }
 
-  /** A VectorSpace for RDD[Double] vectors. */
-  implicit object RDDDoubleVectorSpace extends VectorSpace[RDD[Double]] {
-
-    override def combine(alpha: Double, a: RDD[Double], beta: Double, b: RDD[Double]): RDD[Double] =
-      a.zip(b).map(x => alpha * x._1 + beta * x._2)
-
-    override def dot(a: RDD[Double], b: RDD[Double]): Double =
-      a.zip(b).treeAggregate(0.0)((sum, x) => sum + x._1 * x._2, _ + _)
-
-    override def cache(a: RDD[Double]): Unit = a.cache()
-  }
-
   /** A VectorSpace for DVector vectors. */
   implicit object DVectorVectorSpace extends VectorSpace[DVector] {
 

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpace.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpace.scala
@@ -80,7 +80,10 @@ object VectorSpace {
     import org.apache.spark.mllib.optimization.tfocs.DVectorFunctions._
 
     override def combine(alpha: Double, a: DVector, beta: Double, b: DVector): DVector =
-      a.zipElements(b, (a_i, b_i) => alpha * a_i + beta * b_i)
+      a.zip(b).map(_ match {
+        case (aPart, bPart) =>
+          SimpleVectorSpace.combine(alpha, aPart, beta, bPart)
+      })
 
     override def dot(a: DVector, b: DVector): Double =
       a.zip(b).treeAggregate(0.0)((sum, x) => sum + BLAS.dot(x._1, x._2), _ + _)

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/Lasso.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/Lasso.scala
@@ -17,6 +17,15 @@
 
 package org.apache.spark.mllib.optimization.tfocs.examples
 
+import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.mllib.optimization.tfocs.{
+  ProductVectorRDDVector,
+  ProxL1Vector,
+  SmoothQuadRDDVector,
+  TFOCS
+}
+import org.apache.spark.rdd.RDD
+
 /** Helper to solve lasso regression problems using the tfocs implementation. */
 object SolverLasso {
 

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/Lasso.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/Lasso.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.optimization.tfocs.examples
+
+/** Helper to solve lasso regression problems using the tfocs implementation. */
+object SolverLasso {
+
+  /**
+   * Run a lasso solver on the provided data, using the tfocs implementation.
+   *
+   * @param A The design matrix, an represented as an RDD of row vectors.
+   * @param b The observed values, a column vector of doubles represented as an RDD[Vector]. The
+   *        double values within each partition are collected into Vectors for improved performance.
+   *        The values of b must be co-partitioned with those of A.
+   * @param lambda The regularization term.
+   * @param x0 The starting weights.
+   *
+   * @return The optimized weights returned by the solver.
+   */
+  def run(A: RDD[Vector], b: RDD[Vector], lambda: Double, x0: Vector): Vector =
+    TFOCS.optimize(new SmoothQuadRDDVector(b),
+      new ProductVectorRDDVector(A),
+      new ProxL1Vector(lambda),
+      x0)._1
+}

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/Lasso.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/Lasso.scala
@@ -19,11 +19,12 @@ package org.apache.spark.mllib.optimization.tfocs.examples
 
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.mllib.optimization.tfocs.{
-  ProductVectorRDDVector,
+  ProductVectorDVector,
   ProxL1Vector,
-  SmoothQuadRDDVector,
+  SmoothQuadDVector,
   TFOCS
 }
+import org.apache.spark.mllib.optimization.tfocs.VectorSpace._
 import org.apache.spark.rdd.RDD
 
 /** Helper to solve lasso regression problems using the tfocs implementation. */
@@ -32,18 +33,16 @@ object SolverLasso {
   /**
    * Run a lasso solver on the provided data, using the tfocs implementation.
    *
-   * @param A The design matrix, an represented as an RDD of row vectors.
-   * @param b The observed values, a column vector of doubles represented as an RDD[Vector]. The
-   *        double values within each partition are collected into Vectors for improved performance.
-   *        The values of b must be co-partitioned with those of A.
+   * @param A The design matrix, represented as a DMatrix.
+   * @param b The observed values, represented as a DVector.
    * @param lambda The regularization term.
    * @param x0 The starting weights.
    *
    * @return The optimized weights returned by the solver.
    */
-  def run(A: RDD[Vector], b: RDD[Vector], lambda: Double, x0: Vector): Vector =
-    TFOCS.optimize(new SmoothQuadRDDVector(b),
-      new ProductVectorRDDVector(A),
+  def run(A: DMatrix, b: DVector, lambda: Double, x0: Vector): Vector =
+    TFOCS.optimize(new SmoothQuadDVector(b),
+      new ProductVectorDVector(A),
       new ProxL1Vector(lambda),
       x0)._1
 }

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/Lasso.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/Lasso.scala
@@ -25,7 +25,6 @@ import org.apache.spark.mllib.optimization.tfocs.{
   TFOCS
 }
 import org.apache.spark.mllib.optimization.tfocs.VectorSpace._
-import org.apache.spark.rdd.RDD
 
 /** Helper to solve lasso regression problems using the tfocs implementation. */
 object SolverLasso {

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/LinearFunctionSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/LinearFunctionSuite.scala
@@ -42,26 +42,26 @@ class LinearFunctionSuite extends FunSuite with MLlibTestSparkContext with Match
       "should return the correct product")
   }
 
-  test("ProductVectorRDDVector multiplies properly") {
+  test("ProductVectorDVector multiplies properly") {
 
     assert(Array(50.0, 122.0).deep ==
-      new ProductVectorRDDVector(matrix)(
+      new ProductVectorDVector(matrix)(
         Vectors.dense(7.0, 8.0, 9.0)).flatMap(_.toArray).collect().deep,
       "should return the correct product")
   }
 
-  test("TransposeProductVectorRDDVector multiplies properly") {
+  test("TransposeProductVectorDVector multiplies properly") {
 
     assert(Vectors.dense(29.0, 40.0, 51.0) ==
-      new TransposeProductVectorRDDVector(matrix)(sc.parallelize(Array(Vectors.dense(5.0),
+      new TransposeProductVectorDVector(matrix)(sc.parallelize(Array(Vectors.dense(5.0),
         Vectors.dense(6.0)), 2)),
       "should return the correct product")
   }
 
-  test("TransposeProductVectorRDDVector checks for mismatched partition vectors") {
+  test("TransposeProductVectorDVector checks for mismatched partition vectors") {
 
     a[SparkException] should be thrownBy {
-      new TransposeProductVectorRDDVector(matrix)(sc.parallelize(Array(Vectors.dense(5.0, 6.0),
+      new TransposeProductVectorDVector(matrix)(sc.parallelize(Array(Vectors.dense(5.0, 6.0),
         Vectors.zeros(0)), 2))
     }
   }

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/LinearFunctionSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/LinearFunctionSuite.scala
@@ -28,20 +28,6 @@ class LinearFunctionSuite extends FunSuite with MLlibTestSparkContext with Match
   lazy val matrix = sc.parallelize(Array(Vectors.dense(1.0, 2.0, 3.0),
     Vectors.dense(4.0, 5.0, 6.0)))
 
-  test("ProductVectorRDDDouble multiplies properly") {
-
-    assert(Array(50.0, 122.0).deep ==
-      new ProductVectorRDDDouble(matrix)(Vectors.dense(7.0, 8.0, 9.0)).collect().deep,
-      "should return the correct product")
-  }
-
-  test("TransposeProductVectorRDDDouble multiplies properly") {
-
-    assert(Vectors.dense(29.0, 40.0, 51.0) ==
-      new TransposeProductVectorRDDDouble(matrix)(sc.parallelize(Array(5.0, 6.0))),
-      "should return the correct product")
-  }
-
   test("ProductVectorDVector multiplies properly") {
 
     assert(Array(50.0, 122.0).deep ==

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunctionSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunctionSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.optimization.tfocs
+
+import org.scalatest.{ FunSuite, Matchers }
+
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+
+class ProxCapableFunctionSuite extends FunSuite with Matchers {
+
+  test("The ProxZeroVector implementation should return the expected value and vector") {
+    val x = Vectors.dense(10.0, -20.0, 30.0)
+    assert(new ProxZeroVector()(x) == 0.0, "value should be correct")
+    val Value(Some(f), Some(g)) = new ProxZeroVector()(x, 1.5, Mode(true, true))
+    assert(f == 0.0, "minimum value should be correct")
+    assert(g == Vectors.dense(10.0, -20.0, 30.0), "minimizing value should be correct")
+  }
+
+  test("The ProxL1Vector implementation should return the expected value and vector") {
+    val x = Vectors.dense(10.0, -20.0, 30.0)
+    assert(new ProxL1Vector(1.1)(x) == 66.0, "value should be correct")
+    val Value(Some(f), Some(g)) = new ProxL1Vector(1.1)(x, 1.5, Mode(true, true))
+    assert(f == 60.555, "minimum value should be correct")
+    assert(g == Vectors.dense(8.35, -18.35, 28.349999999999998),
+      "minimizing value should be correct")
+  }
+}

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunctionSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunctionSuite.scala
@@ -48,12 +48,14 @@ class ProxCapableFunctionSuite extends FunSuite with Matchers {
     val Value(Some(f1), Some(g1)) = new ProjRPlusVector()(x1, 1.0, Mode(true, true))
     assert(f1 == 0.0, "value should be correct")
     assert(g1 == x1, "vector should be correct")
+    assert(0.0 == new ProjRPlusVector()(x1))
 
     // Some negative elements.
     val x2 = Vectors.dense(-10.0, 20.0, -30.0)
     val Value(Some(f2), Some(g2)) = new ProjRPlusVector()(x2, 1.0, Mode(true, true))
     assert(f2 == 0.0, "value should be correct")
     assert(g2 == Vectors.dense(0.0, 20.0, 0.0), "vector should be correct")
+    assert(Double.PositiveInfinity == new ProjRPlusVector()(x2))
   }
 
   test("The ProjBoxVector implementation should return the expected value and vector") {
@@ -65,6 +67,7 @@ class ProxCapableFunctionSuite extends FunSuite with Matchers {
         Vectors.dense(11, 21, 31))(x1, 1.0, Mode(true, true))
     assert(f1 == 0.0, "value should be correct")
     assert(g1 == x1, "vector should be correct")
+    assert(0.0 == new ProjBoxVector(Vectors.dense(9, 19, 29), Vectors.dense(11, 21, 31))(x1))
 
     // Some elements outside box.
     val x2 = Vectors.dense(10.0, 20.0, 30.0)
@@ -73,5 +76,9 @@ class ProxCapableFunctionSuite extends FunSuite with Matchers {
         Vectors.dense(11, 21, 29.5))(x2, 1.0, Mode(true, true))
     assert(f2 == 0.0, "value should be correct")
     assert(g2 == Vectors.dense(10.5, 20, 29.5), "vector should be correct")
+    assert(Double.PositiveInfinity ==
+      new ProjBoxVector(Vectors.dense(10.5, 19, 29), Vectors.dense(11, 21, 31))(x2))
+    assert(Double.PositiveInfinity ==
+      new ProjBoxVector(Vectors.dense(10, 19, 29), Vectors.dense(11, 21, 29.5))(x2))
   }
 }

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunctionSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/ProxCapableFunctionSuite.scala
@@ -40,4 +40,38 @@ class ProxCapableFunctionSuite extends FunSuite with Matchers {
     assert(g == Vectors.dense(8.35, -18.35, 28.349999999999998),
       "minimizing value should be correct")
   }
+
+  test("The ProjRPlusVector implementation should return the expected value and vector") {
+
+    // Already nonnegative.
+    val x1 = Vectors.dense(10.0, 20.0, 30.0)
+    val Value(Some(f1), Some(g1)) = new ProjRPlusVector()(x1, 1.0, Mode(true, true))
+    assert(f1 == 0.0, "value should be correct")
+    assert(g1 == x1, "vector should be correct")
+
+    // Some negative elements.
+    val x2 = Vectors.dense(-10.0, 20.0, -30.0)
+    val Value(Some(f2), Some(g2)) = new ProjRPlusVector()(x2, 1.0, Mode(true, true))
+    assert(f2 == 0.0, "value should be correct")
+    assert(g2 == Vectors.dense(0.0, 20.0, 0.0), "vector should be correct")
+  }
+
+  test("The ProjBoxVector implementation should return the expected value and vector") {
+
+    // Already within box.
+    val x1 = Vectors.dense(10.0, 20.0, 30.0)
+    val Value(Some(f1), Some(g1)) =
+      new ProjBoxVector(Vectors.dense(9, 19, 29),
+        Vectors.dense(11, 21, 31))(x1, 1.0, Mode(true, true))
+    assert(f1 == 0.0, "value should be correct")
+    assert(g1 == x1, "vector should be correct")
+
+    // Some elements outside box.
+    val x2 = Vectors.dense(10.0, 20.0, 30.0)
+    val Value(Some(f2), Some(g2)) =
+      new ProjBoxVector(Vectors.dense(10.5, 19, 29),
+        Vectors.dense(11, 21, 29.5))(x2, 1.0, Mode(true, true))
+    assert(f2 == 0.0, "value should be correct")
+    assert(g2 == Vectors.dense(10.5, 20, 29.5), "vector should be correct")
+  }
 }

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunctionSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunctionSuite.scala
@@ -22,6 +22,7 @@ import org.scalatest.{ FunSuite, Matchers }
 import org.apache.spark.SparkException
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.mllib.util.TestingUtils._
 
 class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext with Matchers {
 
@@ -61,5 +62,51 @@ class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext with Match
     a[SparkException] should be thrownBy {
       new SmoothQuadRDDVector(x0)(x, Mode(true, true))
     }
+  }
+
+  test("The SmoothHuberRDDVector implementation should return the expected value and gradient") {
+
+    val x0 = sc.parallelize(Array(Vectors.dense(1.0, 2.0), Vectors.dense(-3.0, -4.0)), 2)
+    val x = sc.parallelize(Array(Vectors.dense(1.1, 1.8), Vectors.dense(-3.3, -3.6)), 2)
+
+    val Value(Some(f2), Some(g2)) = new SmoothHuberRDDVector(x0, 0.2)(x, Mode(true, true))
+
+    assert(f2 ~= .5 * .1 * .1 / .2 + .5 * .2 * .2 / .2 + .3 - .2 / 2 + .4 - .2 / 2 relTol 1e-15,
+      "function value should be correct")
+
+    assert(Vectors.dense(g2.flatMap(_.toArray).collect()) ~=
+      Vectors.dense(.1 / .2, -.2 / .2, -.3 / .3, .4 / .4) relTol 1e-15,
+      "function gradient should be correct")
+
+    val Value(Some(f3), Some(g3)) = new SmoothHuberRDDVector(x0, 0.3)(x, Mode(true, true))
+
+    assert(f3 ~=
+      .5 * .1 * .1 / .3 + .5 * .2 * .2 / .3 + .5 * .3 * .3 / .3 + .4 - .3 / 2 relTol 1e-15,
+      "function value should be correct")
+
+    assert(Vectors.dense(g3.flatMap(_.toArray).collect()) ~=
+      Vectors.dense(.1 / .3, -.2 / .3, -.3 / .3, .4 / .4) relTol 1e-15,
+      "function gradient should be correct")
+  }
+
+  test("The SmoothLogLLogisticRDDVector should return the expected value and gradient") {
+
+    val y = sc.parallelize(Array(Vectors.dense(1.0, 0.0), Vectors.dense(0.0, 1.0, 1.0)), 2)
+    val mu = sc.parallelize(Array(Vectors.dense(0.1, -0.2), Vectors.dense(0.3, -0.4, 0.0)), 2)
+
+    val Value(Some(f), Some(g)) = new SmoothLogLLogisticRDDVector(y)(mu, Mode(true, true))
+
+    assert(f == 0 - math.log1p(math.exp(-0.1)) + 0 - math.log1p(math.exp(-0.2)) +
+      -1 * 0.3 - math.log1p(math.exp(-0.3)) + 1 * -0.4 - math.log1p(math.exp(-0.4)) +
+      0 - math.log1p(math.exp(0)),
+      "function value should be correct")
+
+    assert(Vectors.dense(g.flatMap(_.toArray).collect()) ==
+      Vectors.dense(1.0 - 1.0 / (1.0 + math.exp(-0.1)),
+        0.0 - math.exp(-0.2) / (1.0 + math.exp(-0.2)),
+        0.0 - 1.0 / (1.0 + math.exp(-0.3)),
+        1.0 - math.exp(-0.4) / (1.0 + math.exp(-0.4)),
+        1.0 - math.exp(0.0) / (1.0 + math.exp(0.0))),
+      "function gradient should be correct")
   }
 }

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunctionSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunctionSuite.scala
@@ -40,12 +40,12 @@ class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext with Match
       "function gradient should be correct")
   }
 
-  test("The SmoothQuadRDDVector implementation should return the expected value and gradient") {
+  test("The SmoothQuadDVector implementation should return the expected value and gradient") {
 
     val x0 = sc.parallelize(Array(Vectors.dense(1.0, 2.0), Vectors.dense(3.0)), 2)
     val x = sc.parallelize(Array(Vectors.dense(10.0, 20.0), Vectors.dense(30.0)), 2)
 
-    val Value(Some(f), Some(g)) = new SmoothQuadRDDVector(x0)(x, Mode(true, true))
+    val Value(Some(f), Some(g)) = new SmoothQuadDVector(x0)(x, Mode(true, true))
 
     assert(f == (math.pow(10 - 1, 2) + math.pow(20 - 2, 2) + math.pow(30 - 3, 2)) / 2,
       "function value should be correct")
@@ -54,22 +54,22 @@ class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext with Match
       "function gradient should be correct")
   }
 
-  test("The SmoothQuadRDDVector checks for mismatched partition vectors") {
+  test("The SmoothQuadDVector checks for mismatched partition vectors") {
 
     val x0 = sc.parallelize(Array(Vectors.dense(1.0), Vectors.dense(2.0, 3.0)), 2)
     val x = sc.parallelize(Array(Vectors.dense(10.0, 20.0), Vectors.dense(30.0)), 2)
 
     a[SparkException] should be thrownBy {
-      new SmoothQuadRDDVector(x0)(x, Mode(true, true))
+      new SmoothQuadDVector(x0)(x, Mode(true, true))
     }
   }
 
-  test("The SmoothHuberRDDVector implementation should return the expected value and gradient") {
+  test("The SmoothHuberDVector implementation should return the expected value and gradient") {
 
     val x0 = sc.parallelize(Array(Vectors.dense(1.0, 2.0), Vectors.dense(-3.0, -4.0)), 2)
     val x = sc.parallelize(Array(Vectors.dense(1.1, 1.8), Vectors.dense(-3.3, -3.6)), 2)
 
-    val Value(Some(f2), Some(g2)) = new SmoothHuberRDDVector(x0, 0.2)(x, Mode(true, true))
+    val Value(Some(f2), Some(g2)) = new SmoothHuberDVector(x0, 0.2)(x, Mode(true, true))
 
     assert(f2 ~= .5 * .1 * .1 / .2 + .5 * .2 * .2 / .2 + .3 - .2 / 2 + .4 - .2 / 2 relTol 1e-15,
       "function value should be correct")
@@ -78,7 +78,7 @@ class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext with Match
       Vectors.dense(.1 / .2, -.2 / .2, -.3 / .3, .4 / .4) relTol 1e-15,
       "function gradient should be correct")
 
-    val Value(Some(f3), Some(g3)) = new SmoothHuberRDDVector(x0, 0.3)(x, Mode(true, true))
+    val Value(Some(f3), Some(g3)) = new SmoothHuberDVector(x0, 0.3)(x, Mode(true, true))
 
     assert(f3 ~=
       .5 * .1 * .1 / .3 + .5 * .2 * .2 / .3 + .5 * .3 * .3 / .3 + .4 - .3 / 2 relTol 1e-15,
@@ -89,12 +89,12 @@ class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext with Match
       "function gradient should be correct")
   }
 
-  test("The SmoothLogLLogisticRDDVector should return the expected value and gradient") {
+  test("The SmoothLogLLogisticDVector should return the expected value and gradient") {
 
     val y = sc.parallelize(Array(Vectors.dense(1.0, 0.0), Vectors.dense(0.0, 1.0, 1.0)), 2)
     val mu = sc.parallelize(Array(Vectors.dense(0.1, -0.2), Vectors.dense(0.3, -0.4, 0.0)), 2)
 
-    val Value(Some(f), Some(g)) = new SmoothLogLLogisticRDDVector(y)(mu, Mode(true, true))
+    val Value(Some(f), Some(g)) = new SmoothLogLLogisticDVector(y)(mu, Mode(true, true))
 
     assert(f == 0 - math.log1p(math.exp(-0.1)) + 0 - math.log1p(math.exp(-0.2)) +
       -1 * 0.3 - math.log1p(math.exp(-0.3)) + 1 * -0.4 - math.log1p(math.exp(-0.4)) +

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunctionSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunctionSuite.scala
@@ -26,20 +26,6 @@ import org.apache.spark.mllib.util.TestingUtils._
 
 class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext with Matchers {
 
-  test("The SmoothQuadRDDDouble implementation should return the expected value and gradient") {
-
-    val x0 = sc.parallelize(Array(1.0, 2.0, 3.0))
-    val x = sc.parallelize(Array(10.0, 20.0, 30.0))
-
-    val Value(Some(f), Some(g)) = new SmoothQuadRDDDouble(x0)(x, Mode(true, true))
-
-    assert(f == (math.pow(10 - 1, 2) + math.pow(20 - 2, 2) + math.pow(30 - 3, 2)) / 2,
-      "function value should be correct")
-
-    assert(g.collect().deep == Array(10.0 - 1.0, 20.0 - 2.0, 30.0 - 3.0).deep,
-      "function gradient should be correct")
-  }
-
   test("The SmoothQuadDVector implementation should return the expected value and gradient") {
 
     val x0 = sc.parallelize(Array(Vectors.dense(1.0, 2.0), Vectors.dense(3.0)), 2)

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/TFOCSSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/TFOCSSuite.scala
@@ -59,8 +59,8 @@ class TFOCSSuite extends FunSuite with MLlibTestSparkContext with Matchers {
     val lambda = 0.0298
     val x0 = Vectors.zeros(10)
 
-    val (x, lossHistory) = TFOCS.optimize(new SmoothQuadRDDVector(b),
-      new ProductVectorRDDVector(A),
+    val (x, lossHistory) = TFOCS.optimize(new SmoothQuadDVector(b),
+      new ProductVectorDVector(A),
       new ProxL1Vector(lambda),
       x0)
 

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpaceSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpaceSuite.scala
@@ -35,18 +35,6 @@ class VectorSpaceSuite extends FunSuite with MLlibTestSparkContext with Matchers
       "SimpleVectorSpace.dot should return the correct result.")
   }
 
-  test("RDDDoubleVectorSpace is implemented properly") {
-    assert(Array(22.2, 27.3).deep ==
-      VectorSpace.RDDDoubleVectorSpace.combine(1.1, sc.parallelize(Array(2.0, 3.0)),
-        4.0, sc.parallelize(Array(5.0, 6.0))).collect().deep,
-      "RDDDoubleVectorSpace.combine should return the correct result.")
-
-    assert(28 ==
-      VectorSpace.RDDDoubleVectorSpace.dot(sc.parallelize(Array(2.0, 3.0)),
-        sc.parallelize(Array(5.0, 6.0))),
-      "RDDDoubleVectorSpace.dot should return the correct result.")
-  }
-
   test("DVectorVectorSpace is implemented properly") {
     assert(Array(22.2, 27.3, 32.4).deep ==
       VectorSpace.DVectorVectorSpace.combine(1.1,

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpaceSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpaceSuite.scala
@@ -47,19 +47,19 @@ class VectorSpaceSuite extends FunSuite with MLlibTestSparkContext with Matchers
       "RDDDoubleVectorSpace.dot should return the correct result.")
   }
 
-  test("RDDVectorVectorSpace is implemented properly") {
+  test("DVectorVectorSpace is implemented properly") {
     assert(Array(22.2, 27.3, 32.4).deep ==
-      VectorSpace.RDDVectorVectorSpace.combine(1.1,
+      VectorSpace.DVectorVectorSpace.combine(1.1,
         sc.parallelize(Array(Vectors.dense(2.0, 3.0), Vectors.dense(4.0)), 2),
         4.0,
         sc.parallelize(Array(Vectors.dense(5.0, 6.0), Vectors.dense(7.0)), 2))
       .flatMap(_.toArray).collect().deep,
-      "RDDVectorVectorSpace.combine should return the correct result.")
+      "DVectorVectorSpace.combine should return the correct result.")
 
     assert(56 ==
-      VectorSpace.RDDVectorVectorSpace.dot(
+      VectorSpace.DVectorVectorSpace.dot(
         sc.parallelize(Array(Vectors.dense(2.0, 3.0), Vectors.dense(4.0)), 2),
         sc.parallelize(Array(Vectors.dense(5.0, 6.0), Vectors.dense(7.0)), 2)),
-      "RDDVectorVectorSpace.dot should return the correct result.")
+      "DVectorVectorSpace.dot should return the correct result.")
   }
 }

--- a/src/test/scala/org/apache/spark/mllib/util/TestingUtils.scala
+++ b/src/test/scala/org/apache/spark/mllib/util/TestingUtils.scala
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.util
+
+import org.apache.spark.mllib.linalg.{ Matrix, Vector }
+import org.scalatest.exceptions.TestFailedException
+
+object TestingUtils {
+
+  val ABS_TOL_MSG = " using absolute tolerance"
+  val REL_TOL_MSG = " using relative tolerance"
+
+  /**
+   * Private helper function for comparing two values using relative tolerance.
+   * Note that if x or y is extremely close to zero, i.e., smaller than Double.MinPositiveValue,
+   * the relative tolerance is meaningless, so the exception will be raised to warn users.
+   */
+  private def RelativeErrorComparison(x: Double, y: Double, eps: Double): Boolean = {
+    val absX = math.abs(x)
+    val absY = math.abs(y)
+    val diff = math.abs(x - y)
+    if (x == y) {
+      true
+    } else if (absX < Double.MinPositiveValue || absY < Double.MinPositiveValue) {
+      throw new TestFailedException(
+        s"$x or $y is extremely close to zero, so the relative tolerance is meaningless.", 0)
+    } else {
+      diff < eps * math.min(absX, absY)
+    }
+  }
+
+  /**
+   * Private helper function for comparing two values using absolute tolerance.
+   */
+  private def AbsoluteErrorComparison(x: Double, y: Double, eps: Double): Boolean = {
+    math.abs(x - y) < eps
+  }
+
+  case class CompareDoubleRightSide(
+    fun: (Double, Double, Double) => Boolean, y: Double, eps: Double, method: String)
+
+  /**
+   * Implicit class for comparing two double values using relative tolerance or absolute tolerance.
+   */
+  implicit class DoubleWithAlmostEquals(val x: Double) {
+
+    /**
+     * When the difference of two values are within eps, returns true; otherwise, returns false.
+     */
+    def ~=(r: CompareDoubleRightSide): Boolean = r.fun(x, r.y, r.eps)
+
+    /**
+     * When the difference of two values are within eps, returns false; otherwise, returns true.
+     */
+    def !~=(r: CompareDoubleRightSide): Boolean = !r.fun(x, r.y, r.eps)
+
+    /**
+     * Throws exception when the difference of two values are NOT within eps;
+     * otherwise, returns true.
+     */
+    def ~==(r: CompareDoubleRightSide): Boolean = {
+      if (!r.fun(x, r.y, r.eps)) {
+        throw new TestFailedException(
+          s"Expected $x and ${r.y} to be within ${r.eps}${r.method}.", 0)
+      }
+      true
+    }
+
+    /**
+     * Throws exception when the difference of two values are within eps; otherwise, returns true.
+     */
+    def !~==(r: CompareDoubleRightSide): Boolean = {
+      if (r.fun(x, r.y, r.eps)) {
+        throw new TestFailedException(
+          s"Did not expect $x and ${r.y} to be within ${r.eps}${r.method}.", 0)
+      }
+      true
+    }
+
+    /**
+     * Comparison using absolute tolerance.
+     */
+    def absTol(eps: Double): CompareDoubleRightSide =
+      CompareDoubleRightSide(AbsoluteErrorComparison, x, eps, ABS_TOL_MSG)
+
+    /**
+     * Comparison using relative tolerance.
+     */
+    def relTol(eps: Double): CompareDoubleRightSide =
+      CompareDoubleRightSide(RelativeErrorComparison, x, eps, REL_TOL_MSG)
+
+    override def toString: String = x.toString
+  }
+
+  case class CompareVectorRightSide(
+    fun: (Vector, Vector, Double) => Boolean, y: Vector, eps: Double, method: String)
+
+  /**
+   * Implicit class for comparing two vectors using relative tolerance or absolute tolerance.
+   */
+  implicit class VectorWithAlmostEquals(val x: Vector) {
+
+    /**
+     * When the difference of two vectors are within eps, returns true; otherwise, returns false.
+     */
+    def ~=(r: CompareVectorRightSide): Boolean = r.fun(x, r.y, r.eps)
+
+    /**
+     * When the difference of two vectors are within eps, returns false; otherwise, returns true.
+     */
+    def !~=(r: CompareVectorRightSide): Boolean = !r.fun(x, r.y, r.eps)
+
+    /**
+     * Throws exception when the difference of two vectors are NOT within eps;
+     * otherwise, returns true.
+     */
+    def ~==(r: CompareVectorRightSide): Boolean = {
+      if (!r.fun(x, r.y, r.eps)) {
+        throw new TestFailedException(
+          s"Expected $x and ${r.y} to be within ${r.eps}${r.method} for all elements.", 0)
+      }
+      true
+    }
+
+    /**
+     * Throws exception when the difference of two vectors are within eps; otherwise, returns true.
+     */
+    def !~==(r: CompareVectorRightSide): Boolean = {
+      if (r.fun(x, r.y, r.eps)) {
+        throw new TestFailedException(
+          s"Did not expect $x and ${r.y} to be within ${r.eps}${r.method} for all elements.", 0)
+      }
+      true
+    }
+
+    /**
+     * Comparison using absolute tolerance.
+     */
+    def absTol(eps: Double): CompareVectorRightSide = CompareVectorRightSide(
+      (x: Vector, y: Vector, eps: Double) => {
+        x.toArray.zip(y.toArray).forall(x => x._1 ~= x._2 absTol eps)
+      }, x, eps, ABS_TOL_MSG)
+
+    /**
+     * Comparison using relative tolerance. Note that comparing against sparse vector
+     * with elements having value of zero will raise exception because it involves with
+     * comparing against zero.
+     */
+    def relTol(eps: Double): CompareVectorRightSide = CompareVectorRightSide(
+      (x: Vector, y: Vector, eps: Double) => {
+        x.toArray.zip(y.toArray).forall(x => x._1 ~= x._2 relTol eps)
+      }, x, eps, REL_TOL_MSG)
+
+    override def toString: String = x.toString
+  }
+}


### PR DESCRIPTION
Previously RDD[Vector] had been used to represent both distributed vectors and matrices. This PR introduces the DVector and DMatrix types to clarify usage when the distributed RDD[Vector] format is used. In addition, new comments describe usage requirements for these datatypes.

Also removes the old, unused function implementations operating on RDD[Double] vectors.

Also adds documentation and clarification of various vector operations throughout the code, including a few optimizations.
