### PR TITLE
Make SmoothDual generic.

### DIFF
--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/DVectorFunctions.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/DVectorFunctions.scala
@@ -69,9 +69,6 @@ private[tfocs] class DVectorFunctions(self: DVector) {
         ret
     })
 
-  def sqdist(other: DVector): Double =
-    self.zip(other).aggregate(0.0)((sum, x) => sum + Vectors.sqdist(x._1, x._2), _ + _)
-
   def sum: Double = self.aggregate(0.0)((sum, x) => sum + x.values.sum, _ + _)
 
   def dot(other: DVector): Double =
@@ -82,12 +79,4 @@ private[tfocs] object DVectorFunctions {
 
   implicit def DVectorToDVectorFunctions(dVector: DVector): DVectorFunctions =
     new DVectorFunctions(dVector)
-
-  def axpy(a: Double, x: DVector, y: DVector) =
-    x.zip(y).map(_ match {
-      case (xPart, yPart) =>
-        val ret = yPart.copy
-        BLAS.axpy(a, xPart, ret)
-        ret
-    })
 }

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/TFOCS_SCD.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/TFOCS_SCD.scala
@@ -19,7 +19,7 @@ package org.apache.spark.mllib.optimization.tfocs
 
 import org.apache.spark.mllib.linalg.DenseVector
 import org.apache.spark.mllib.optimization.tfocs.VectorSpace._
-import org.apache.spark.mllib.optimization.tfocs.fs.dvector.double._
+import org.apache.spark.mllib.optimization.tfocs.fs.generic.double._
 import org.apache.spark.mllib.optimization.tfocs.fs.dvectordouble.double._
 import org.apache.spark.mllib.optimization.tfocs.vs.vector._
 import org.apache.spark.mllib.optimization.tfocs.vs.dvectordouble._

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunctionSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunctionSuite.scala
@@ -24,6 +24,8 @@ import org.apache.spark.mllib.linalg.{ DenseVector, Vectors }
 import org.apache.spark.mllib.optimization.tfocs.DVectorFunctions._
 import org.apache.spark.mllib.optimization.tfocs.fs.dvector.double._
 import org.apache.spark.mllib.optimization.tfocs.fs.dvectordouble.double._
+import org.apache.spark.mllib.optimization.tfocs.fs.generic.double._
+import org.apache.spark.mllib.optimization.tfocs.vs.dvector._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 
@@ -133,8 +135,9 @@ class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext {
     val ProxValue(Some(expectedProxF), Some(expectedProxMinimizer)) =
       objectiveF(expectedOffsetCenter, mu, ProxMode(true, true))
 
+    val diff = x0.diff(expectedProxMinimizer)
     val expectedF = ATz.dot(expectedProxMinimizer) - expectedProxF -
-      (0.5 / mu) * x0.sqdist(expectedProxMinimizer)
+      (0.5 / mu) * diff.dot(diff)
     assert(f == expectedF, "function value should be correct")
 
     val expectedG = expectedProxMinimizer.mapElements(g_i => -g_i)


### PR DESCRIPTION
Makes SmoothDual generic so it can operate on arbitrary VectorSpaces.
