### PR TITLE
Add LASSO and LP examples.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")
 credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 
 libraryDependencies ++= Seq(
+  "com.joptimizer" % "joptimizer" % "3.4.0",
   "org.scalatest" %% "scalatest" % "2.1.5" % Test
 )
 

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SolverL1RLS.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SolverL1RLS.scala
@@ -40,7 +40,7 @@ object SolverL1RLS {
    *
    * @return The optimized weights returned by the solver.
    *
-   * @see [[https://github.com/databricks/spark-tfocs/blob/master/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLASSO.scala]]
+   * @see [[org.apache.spark.mllib.optimization.tfocs.examples.TestLASSO]]
    * for example usage of this function.
    *
    * NOTE The distributed matrix 'A', represented as a DMatrix, and the distributed vector 'b',

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SolverL1RLS.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SolverL1RLS.scala
@@ -40,6 +40,9 @@ object SolverL1RLS {
    *
    * @return The optimized weights returned by the solver.
    *
+   * @see [[https://github.com/databricks/spark-tfocs/blob/master/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLASSO.scala]]
+   * for example usage of this function.
+   *
    * NOTE The distributed matrix 'A', represented as a DMatrix, and the distributed vector 'b',
    * represented as a DVector, supplied to this function must be consistently partitioned. The 'A'
    * matrix must contain the same number of rows in each partition as the 'b' vector has numeric

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SolverSLP.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SolverSLP.scala
@@ -49,8 +49,8 @@ object SolverSLP {
    *
    * @return A tuple comprising the solution x vector and the loss history of the optimization run.
    *
-   * @see [[https://github.com/databricks/spark-tfocs/blob/master/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLinearProgram.scala]]
-   * @see [[https://github.com/databricks/spark-tfocs/blob/master/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestMPSLinearProgram.scala]]
+   * @see [[org.apache.spark.mllib.optimization.tfocs.examples.TestLinearProgram]]
+   * @see [[org.apache.spark.mllib.optimization.tfocs.examples.TestMPSLinearProgram]]
    * for example usage of this function.
    *
    * NOTE The distributed matrix, represented as a DMatrix, and the distributed vectors, represented

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SolverSLP.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SolverSLP.scala
@@ -49,6 +49,10 @@ object SolverSLP {
    *
    * @return A tuple comprising the solution x vector and the loss history of the optimization run.
    *
+   * @see [[https://github.com/databricks/spark-tfocs/blob/master/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLinearProgram.scala]]
+   * @see [[https://github.com/databricks/spark-tfocs/blob/master/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestMPSLinearProgram.scala]]
+   * for example usage of this function.
+   *
    * NOTE The distributed matrix, represented as a DMatrix, and the distributed vectors, represented
    * as DVectors, supplied to this function must be consistently partitioned. The DVectors must
    * all contain the same number of numeric values in each partition. And the DMatrix must contain

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLASSO.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLASSO.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.optimization.tfocs.examples
+
+import scala.util.Random
+
+import org.apache.spark.mllib.linalg.{ BLAS, Vectors }
+import org.apache.spark.mllib.optimization.tfocs.SolverL1RLS
+import org.apache.spark.mllib.random.RandomRDDs
+import org.apache.spark.{ SparkConf, SparkContext }
+
+/**
+ * This example generates a random lasso optimization problem and solves it using SolverL1RLS.
+ *
+ * The example can be executed as follows:
+ * sbt 'test:run-main org.apache.spark.mllib.optimization.tfocs.examples.TestLASSO'
+ *
+ * NOTE In matlab tfocs this functionality can be found in test_LASSO.m.
+ * @see [[https://github.com/cvxr/TFOCS/blob/master/examples/smallscale/test_LASSO.m]]
+ */
+object TestLASSO {
+  def main(args: Array[String]) {
+
+    val rnd = new Random(34324)
+    val sparkConf = new SparkConf().setMaster("local[2]").setAppName("TestLASSO")
+    val sc = new SparkContext(sparkConf)
+
+    val n = 1024 // Design matrix column count.
+    val m = n / 2 // Design matrix row count.
+    val k = m / 5 // Count of nonzero weights.
+
+    // Generate the design matrix using random normal values, then normalize the columns.
+    val unnormalizedA = RandomRDDs.normalVectorRDD(sc, m, n, 0, rnd.nextLong)
+    val AColumnNormSq = unnormalizedA
+      .map(rowA => Vectors.dense(rowA.toArray.map(rowA_i => rowA_i * rowA_i)))
+      .reduce((a, b) => {
+        val ret = b.copy
+        BLAS.axpy(1.0, a, ret)
+        ret
+      })
+    val A = unnormalizedA.map(rowA =>
+      Vectors.dense(rowA.toArray.zip(AColumnNormSq.toArray).map(_ match {
+        case (rowA_i, normsq_i) => rowA_i / math.sqrt(normsq_i)
+      })))
+
+    // Generate the actual 'x' vector, including 'k' nonzero values.
+    val x = Vectors.zeros(n).toDense
+    for (i <- rnd.shuffle(1 to n).take(k)) {
+      x.values(i) = rnd.nextGaussian
+    }
+
+    // Generate the 'b' vector using the design matrix and weights, adding gaussian noise.
+    val bOriginal = Vectors.dense(A.map(rowA => BLAS.dot(rowA, x)).collect).toDense
+    val snr = 30 // SNR in dB
+    val sigma =
+      math.pow(10, ((10 * math.log10(math.pow(Vectors.norm(bOriginal, 2), 2) / n) - snr) / 20))
+    val b = sc.parallelize(bOriginal.values.map(
+      _ + sigma * rnd.nextGaussian)).glom.map(Vectors.dense(_).toDense)
+
+    // Set 'lambda' using the noise standard deviation.
+    val lambda = 2 * sigma * math.sqrt(2 * math.log(n))
+
+    // Solve the lasso problem using SolverL1RLS, finding the estimated x vector 'estimatedX'.
+    val x0 = Vectors.zeros(n).toDense
+    val (estimatedX, _) = SolverL1RLS.run(A, b, lambda, x0)
+    println("estimatedX: " + estimatedX.values.mkString(", "))
+
+    sc.stop()
+  }
+}

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLinearProgram.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLinearProgram.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.optimization.tfocs.examples
+
+import scala.util.Random
+
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.optimization.tfocs.DVectorFunctions._
+import org.apache.spark.mllib.optimization.tfocs.SolverSLP
+import org.apache.spark.mllib.optimization.tfocs.fs.dvector.vector.LinopMatrix
+import org.apache.spark.mllib.random.{ RandomDataGenerator, RandomRDDs }
+import org.apache.spark.mllib.rdd.RandomVectorRDD
+import org.apache.spark.{ SparkConf, SparkContext }
+import org.apache.spark.util.random.XORShiftRandom
+
+/**
+ * Helper class for generating sparse standard normal values.
+ *
+ * @param density The density of non sparse values.
+ */
+private class SparseStandardNormalGenerator(density: Double) extends RandomDataGenerator[Double] {
+
+  private val random = new XORShiftRandom()
+
+  override def nextValue(): Double = if (random.nextDouble < density) random.nextGaussian else 0.0
+
+  override def setSeed(seed: Long): Unit = random.setSeed(seed)
+
+  override def copy(): SparseStandardNormalGenerator = new SparseStandardNormalGenerator(density)
+}
+
+/**
+ * This example generates a random linear programming problem and solves it using SolverSLP.
+ *
+ * The example can be executed as follows:
+ * sbt 'test:run-main org.apache.spark.mllib.optimization.tfocs.examples.TestLinearProgram'
+ *
+ * NOTE In matlab tfocs this example can be found in test_LinearProgram.m.
+ * @see [[https://github.com/cvxr/TFOCS/blob/master/examples/smallscale/test_LinearProgram.m]]
+ */
+object TestLinearProgram {
+  def main(args: Array[String]) {
+
+    val rnd = new Random(34324)
+    val sparkConf = new SparkConf().setMaster("local[2]").setAppName("TestLinearProgram")
+    val sc = new SparkContext(sparkConf)
+
+    val n = 5000 // Tranpose constraint matrix row count.
+    val m = n / 2 // Transpose constrint matrix column count.
+
+    // Generate a starting 'x' vector, using normally generated values.
+    val x = RandomRDDs.normalRDD(sc, n).map(_ + 10).glom.map(Vectors.dense(_).toDense)
+
+    // Generate the transpose constraint matrix 'A' using sparse normally generated values.
+    val A = new RandomVectorRDD(sc,
+      n,
+      m,
+      sc.defaultMinPartitions,
+      new SparseStandardNormalGenerator(0.01),
+      rnd.nextLong)
+
+    // Generate the cost vector 'c' using normally generated values.
+    val c = RandomRDDs.normalRDD(sc, n, 0, rnd.nextLong).glom.map(Vectors.dense(_).toDense)
+
+    // Compute 'b' using the starting 'x' vector.
+    val b = new LinopMatrix(A)(x)
+
+    val mu = 1e-2
+    val x0 = sc.parallelize(new Array[Double](n)).glom.map(Vectors.dense(_).toDense)
+    val z0 = Vectors.zeros(m).toDense
+
+    // Solve the linear program using SolverSLP, finding the optimal x vector 'optimalX'.
+    val (optimalX, _) = SolverSLP.run(c, A, b, mu, x0, z0)
+    println("optimalX: " + optimalX.collectElements.mkString(", "))
+
+    sc.stop()
+  }
+}

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestMPSLinearProgram.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestMPSLinearProgram.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.optimization.tfocs.examples
+
+import java.io.File
+
+import com.joptimizer.optimizers.LPStandardConverter
+import com.joptimizer.util.MPSParser
+
+import org.apache.spark.mllib.linalg.{ Vector, Vectors }
+import org.apache.spark.mllib.optimization.tfocs.DVectorFunctions._
+import org.apache.spark.mllib.optimization.tfocs.SolverSLP
+import org.apache.spark.{ SparkConf, SparkContext }
+
+/**
+ * This example reads a linear program in MPS format and solves it using SolverSLP.
+ *
+ * The example can be executed as follows:
+ * sbt 'test:run-main org.apache.spark.mllib.optimization.tfocs.examples.TestLinearProgram <mps file>'
+ */
+object TestMPSLinearProgram {
+  def main(args: Array[String]) {
+
+    val sparkConf = new SparkConf().setMaster("local[2]").setAppName("TestMPSLinearProgram")
+    val sc = new SparkContext(sparkConf)
+
+    // Parse the provided MPS file.
+    val parser = new MPSParser()
+    var mpsFile = new File(args(0))
+    parser.parse(mpsFile)
+
+    // Convert the parsed linear program to standard form.
+    val converter = new LPStandardConverter(true)
+    converter.toStandardForm(parser.getC,
+      parser.getG,
+      parser.getH,
+      parser.getA,
+      parser.getB,
+      parser.getLb,
+      parser.getUb)
+
+    // Convert the parameters of the linear program to the proper formats.
+    val c = sc.parallelize(converter.getStandardC.toArray).glom.map(Vectors.dense(_).toDense)
+    val A = sc.parallelize(converter.getStandardA.toArray.transpose.map(
+      Vectors.dense(_).toSparse: Vector))
+    val b = Vectors.dense(converter.getStandardB.toArray).toDense
+    val n = converter.getStandardN
+
+    val mu = 1e-2
+    val x0 = sc.parallelize(new Array[Double](n)).glom.map(Vectors.dense(_).toDense)
+    val z0 = Vectors.zeros(b.size).toDense
+
+    // Solve the linear program using SolverSLP, finding the optimal x vector 'optimalX'.
+    val (optimalX, _) = SolverSLP.run(c, A, b, mu, x0, z0)
+    println("optimalX: " + optimalX.collectElements.mkString(", "))
+
+    sc.stop()
+  }
+}

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestMPSLinearProgram.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestMPSLinearProgram.scala
@@ -31,7 +31,8 @@ import org.apache.spark.{ SparkConf, SparkContext }
  * This example reads a linear program in MPS format and solves it using SolverSLP.
  *
  * The example can be executed as follows:
- * sbt 'test:run-main org.apache.spark.mllib.optimization.tfocs.examples.TestLinearProgram <mps file>'
+ * sbt 'test:run-main
+ *   org.apache.spark.mllib.optimization.tfocs.examples.TestLinearProgram <mps file>'
  */
 object TestMPSLinearProgram {
   def main(args: Array[String]) {


### PR DESCRIPTION
Adds some examples including:
- Random LASSO problem, based on tfocs example
- Random LP problem, based on tfocs example
- MPS LP problem solver

Based on https://github.com/databricks/spark-tfocs/pull/16
