### PR TITLE
Some syntax simplifications

### DIFF
--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/DVectorFunctions.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/DVectorFunctions.scala
@@ -30,7 +30,7 @@ private[tfocs] class DVectorFunctions(self: DVector) {
   def mapElements(f: Double => Double): DVector = self.map(x => new DenseVector(x.values.map(f)))
 
   def zipElements(other: DVector, f: (Double, Double) => Double): DVector =
-    self.zip(other).map(_ match {
+    self.zip(other).map {
       case (selfPart, otherPart) =>
         if (selfPart.size != otherPart.size) {
           throw new IllegalArgumentException("Can only zipElements DVectors with the same number " +
@@ -44,7 +44,7 @@ private[tfocs] class DVectorFunctions(self: DVector) {
           i += 1
         }
         new DenseVector(ret)
-    })
+    }
 
   def aggregateElements(zeroValue: Double)(
     seqOp: (Double, Double) => Double,
@@ -62,12 +62,12 @@ private[tfocs] class DVectorFunctions(self: DVector) {
     self.collect().flatMap(_.values)
 
   def diff(other: DVector): DVector =
-    self.zip(other).map(_ match {
+    self.zip(other).map {
       case (selfPart, otherPart) =>
         val ret = selfPart.copy
         BLAS.axpy(-1.0, otherPart, ret)
         ret
-    })
+    }
 
   def sum: Double = self.aggregate(0.0)((sum, x) => sum + x.values.sum, _ + _)
 

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLASSO.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLASSO.scala
@@ -19,7 +19,7 @@ package org.apache.spark.mllib.optimization.tfocs.examples
 
 import scala.util.Random
 
-import org.apache.spark.mllib.linalg.{ BLAS, Vectors }
+import org.apache.spark.mllib.linalg.{ BLAS, DenseVector, Vectors }
 import org.apache.spark.mllib.optimization.tfocs.SolverL1RLS
 import org.apache.spark.mllib.random.RandomRDDs
 import org.apache.spark.{ SparkConf, SparkContext }
@@ -68,13 +68,13 @@ object TestLASSO {
     }
 
     // Generate the 'b' vector using the design matrix and weights, adding gaussian noise.
-    val bOriginal = Vectors.dense(A.map(rowA => BLAS.dot(rowA, x)).collect).toDense
+    val bOriginal = new DenseVector(A.map(rowA => BLAS.dot(rowA, x)).collect)
     val snr = 30 // SNR in dB
     val sigma =
       math.pow(10, ((10 * math.log10(math.pow(Vectors.norm(bOriginal, 2), 2) / n) - snr) / 20))
     val b = sc.parallelize(bOriginal.values.map(_ + sigma * rnd.nextGaussian))
       .glom
-      .map(Vectors.dense(_).toDense)
+      .map(new DenseVector(_))
 
     // Set 'lambda' using the noise standard deviation.
     val lambda = 2 * sigma * math.sqrt(2 * math.log(n))

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLASSO.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLASSO.scala
@@ -57,9 +57,9 @@ object TestLASSO {
         sum1
       })
     val A = unnormalizedA.map(rowA =>
-      Vectors.dense(rowA.toArray.zip(AColumnNormSq.toArray).map(_ match {
+      Vectors.dense(rowA.toArray.zip(AColumnNormSq.toArray).map {
         case (rowA_i, normsq_i) => rowA_i / math.sqrt(normsq_i)
-      })))
+      }))
 
     // Generate the actual 'x' vector, including 'k' nonzero values.
     val x = Vectors.zeros(n).toDense

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLinearProgram.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLinearProgram.scala
@@ -19,7 +19,7 @@ package org.apache.spark.mllib.optimization.tfocs.examples
 
 import scala.util.Random
 
-import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.linalg.{ DenseVector, Vectors }
 import org.apache.spark.mllib.optimization.tfocs.DVectorFunctions._
 import org.apache.spark.mllib.optimization.tfocs.SolverSLP
 import org.apache.spark.mllib.optimization.tfocs.fs.dvector.vector.LinopMatrix
@@ -64,7 +64,7 @@ object TestLinearProgram {
     val m = n / 2 // Transpose constrint matrix column count.
 
     // Generate a starting 'x' vector, using normally generated values.
-    val x = RandomRDDs.normalRDD(sc, n).map(_ + 10).glom.map(Vectors.dense(_).toDense)
+    val x = RandomRDDs.normalRDD(sc, n).map(_ + 10).glom.map(new DenseVector(_))
 
     // Generate the transpose constraint matrix 'A' using sparse normally generated values.
     val A = new RandomVectorRDD(sc,
@@ -75,13 +75,13 @@ object TestLinearProgram {
       rnd.nextLong)
 
     // Generate the cost vector 'c' using normally generated values.
-    val c = RandomRDDs.normalRDD(sc, n, 0, rnd.nextLong).glom.map(Vectors.dense(_).toDense)
+    val c = RandomRDDs.normalRDD(sc, n, 0, rnd.nextLong).glom.map(new DenseVector(_))
 
     // Compute 'b' using the starting 'x' vector.
     val b = new LinopMatrix(A)(x)
 
     val mu = 1e-2
-    val x0 = sc.parallelize(new Array[Double](n)).glom.map(Vectors.dense(_).toDense)
+    val x0 = sc.parallelize(new Array[Double](n)).glom.map(new DenseVector(_))
     val z0 = Vectors.zeros(m).toDense
 
     // Solve the linear program using SolverSLP, finding the optimal x vector 'optimalX'.

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestMPSLinearProgram.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestMPSLinearProgram.scala
@@ -22,7 +22,7 @@ import java.io.File
 import com.joptimizer.optimizers.LPStandardConverter
 import com.joptimizer.util.MPSParser
 
-import org.apache.spark.mllib.linalg.{ Vector, Vectors }
+import org.apache.spark.mllib.linalg.{ DenseVector, Vector, Vectors }
 import org.apache.spark.mllib.optimization.tfocs.DVectorFunctions._
 import org.apache.spark.mllib.optimization.tfocs.SolverSLP
 import org.apache.spark.{ SparkConf, SparkContext }
@@ -56,14 +56,14 @@ object TestMPSLinearProgram {
       parser.getUb)
 
     // Convert the parameters of the linear program to the proper formats.
-    val c = sc.parallelize(converter.getStandardC.toArray).glom.map(Vectors.dense(_).toDense)
+    val c = sc.parallelize(converter.getStandardC.toArray).glom.map(new DenseVector(_))
     val A = sc.parallelize(converter.getStandardA.toArray.transpose.map(
       Vectors.dense(_).toSparse: Vector))
-    val b = Vectors.dense(converter.getStandardB.toArray).toDense
+    val b = new DenseVector(converter.getStandardB.toArray)
     val n = converter.getStandardN
 
     val mu = 1e-2
-    val x0 = sc.parallelize(new Array[Double](n)).glom.map(Vectors.dense(_).toDense)
+    val x0 = sc.parallelize(new Array[Double](n)).glom.map(new DenseVector(_))
     val z0 = Vectors.zeros(b.size).toDense
 
     // Solve the linear program using SolverSLP, finding the optimal x vector 'optimalX'.

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/vs/dvector/package.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/vs/dvector/package.scala
@@ -36,11 +36,11 @@ package object dvector {
         // optimized.
         a
       } else {
-        a.zip(b).map(_ match {
+        a.zip(b).map {
           case (aPart, bPart) =>
             // NOTE A DenseVector result is assumed here (not sparse safe).
             DenseVectorSpace.combine(alpha, aPart, beta, bPart).toDense
-        })
+        }
       }
 
     override def dot(a: DVector, b: DVector): Double = a.dot(b)

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/LinearOperatorSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/LinearOperatorSuite.scala
@@ -33,12 +33,12 @@ class LinearOperatorSuite extends FunSuite with MLlibTestSparkContext {
   lazy val matrix = sc.parallelize(Array(Vectors.dense(1.0, 2.0, 3.0),
     Vectors.dense(4.0, 5.0, 6.0)), 2)
 
-  lazy val vector = Vectors.dense(2.2, 3.3, 4.4).toDense
+  lazy val vector = new DenseVector(Array(2.2, 3.3, 4.4))
 
   test("LinopMatrix multiplies properly") {
 
     val f = new LinopMatrix(matrix)
-    val x = Vectors.dense(7.0, 8.0, 9.0).toDense
+    val x = new DenseVector(Array(7.0, 8.0, 9.0))
     val result = f(x)
     val expectedResult = Vectors.dense(1 * 7 + 2 * 8 + 3 * 9, 4 * 7 + 5 * 8 + 6 * 9)
     assert(Vectors.dense(result.collectElements) == expectedResult,
@@ -48,7 +48,7 @@ class LinearOperatorSuite extends FunSuite with MLlibTestSparkContext {
   test("LinopMatrixAdjoint multiplies properly") {
 
     val f = new LinopMatrixAdjoint(matrix)
-    val y = sc.parallelize(Array(Vectors.dense(5.0).toDense, Vectors.dense(6.0).toDense), 2)
+    val y = sc.parallelize(Array(new DenseVector(Array(5.0)), new DenseVector(Array(6.0))), 2)
     val result = f(y)
     val expectedResult = Vectors.dense(1 * 5 + 4 * 6, 2 * 5 + 5 * 6, 3 * 5 + 6 * 6)
     assert(result == expectedResult, "should return the correct product")
@@ -57,7 +57,7 @@ class LinearOperatorSuite extends FunSuite with MLlibTestSparkContext {
   test("LinopMatrixAdjoint checks for mismatched partition vectors") {
 
     val f = new LinopMatrixAdjoint(matrix)
-    val y = sc.parallelize(Array(Vectors.dense(5.0, 6.0).toDense, Vectors.zeros(0).toDense), 2)
+    val y = sc.parallelize(Array(new DenseVector(Array(5.0, 6.0)), Vectors.zeros(0).toDense), 2)
     intercept[SparkException] {
       f(y)
     }
@@ -66,9 +66,9 @@ class LinearOperatorSuite extends FunSuite with MLlibTestSparkContext {
   test("LinopMatrixVector multiplies properly") {
 
     val f = new LinopMatrixVector(matrix, vector)
-    val x = Vectors.dense(7.0, 8.0, 9.0).toDense
+    val x = new DenseVector(Array(7.0, 8.0, 9.0))
     val result = f(x)
-    val expectedResult = (Vectors.dense(1 * 7 + 2 * 8 + 3 * 9, 4 * 7 + 5 * 8 + 6 * 9).toDense,
+    val expectedResult = (new DenseVector(Array(1 * 7 + 2 * 8 + 3 * 9, 4 * 7 + 5 * 8 + 6 * 9)),
       7.0 * 2.2 + 8.0 * 3.3 + 9.0 * 4.4)
     assert(Vectors.dense(result._1.collectElements) == expectedResult._1,
       "should return the correct product")
@@ -78,7 +78,8 @@ class LinearOperatorSuite extends FunSuite with MLlibTestSparkContext {
   test("LinopMatrixVectorAdjoint multiplies properly") {
 
     var f = new LinopMatrixVectorAdjoint(matrix, vector)
-    val y = (sc.parallelize(Array(Vectors.dense(5.0).toDense, Vectors.dense(6.0).toDense), 2), 8.8)
+    val y = (sc.parallelize(Array(new DenseVector(Array(5.0)), new DenseVector(Array(6.0))), 2),
+      8.8)
     val result = f(y)
     val expectedResult =
       Vectors.dense(1 * 5 + 4 * 6 + 2.2, 2 * 5 + 5 * 6 + 3.3, 3 * 5 + 6 * 6 + 4.4)
@@ -88,7 +89,7 @@ class LinearOperatorSuite extends FunSuite with MLlibTestSparkContext {
   test("LinopMatrixVectorAdjoint checks for mismatched partition vectors") {
 
     val f = new LinopMatrixVectorAdjoint(matrix, vector)
-    val y = (sc.parallelize(Array(Vectors.dense(5.0, 6.0).toDense, Vectors.zeros(0).toDense), 2),
+    val y = (sc.parallelize(Array(new DenseVector(Array(5.0, 6.0)), Vectors.zeros(0).toDense), 2),
       8.8)
     intercept[SparkException] {
       f(y)

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunctionSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SmoothFunctionSuite.scala
@@ -33,8 +33,9 @@ class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext {
 
   test("The SmoothQuad implementation should return the expected value and gradient") {
 
-    val x0 = sc.parallelize(Array(Vectors.dense(1.0, 2.0).toDense, Vectors.dense(3.0).toDense), 2)
-    val x = sc.parallelize(Array(Vectors.dense(10.0, 20.0).toDense, Vectors.dense(30.0).toDense), 2)
+    val x0 = sc.parallelize(Array(new DenseVector(Array(1.0, 2.0)), new DenseVector(Array(3.0))), 2)
+    val x = sc.parallelize(Array(new DenseVector(Array(10.0, 20.0)), new DenseVector(Array(30.0))),
+      2)
     val fun = new SmoothQuad(x0)
 
     val Value(Some(f), Some(g)) = fun(x, Mode(true, true))
@@ -50,8 +51,9 @@ class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext {
   test("The SmoothQuad implementation checks for mismatched partition vectors") {
 
     // x0 and x do not have the same number of vector values in each partition.
-    val x0 = sc.parallelize(Array(Vectors.dense(1.0).toDense, Vectors.dense(2.0, 3.0).toDense), 2)
-    val x = sc.parallelize(Array(Vectors.dense(10.0, 20.0).toDense, Vectors.dense(30.0).toDense), 2)
+    val x0 = sc.parallelize(Array(new DenseVector(Array(1.0)), new DenseVector(Array(2.0, 3.0))), 2)
+    val x = sc.parallelize(Array(new DenseVector(Array(10.0, 20.0)), new DenseVector(Array(30.0))),
+      2)
     val fun = new SmoothQuad(x0)
 
     intercept[SparkException] {
@@ -61,10 +63,10 @@ class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext {
 
   test("The SmoothHuber implementation should return the expected value and gradient") {
 
-    val x0 = sc.parallelize(Array(Vectors.dense(1.0, 2.0).toDense,
-      Vectors.dense(-3.0, -4.0).toDense), 2)
-    val x = sc.parallelize(Array(Vectors.dense(1.1, 1.8).toDense,
-      Vectors.dense(-3.3, -3.6).toDense), 2)
+    val x0 = sc.parallelize(Array(new DenseVector(Array(1.0, 2.0)),
+      new DenseVector(Array(-3.0, -4.0))), 2)
+    val x = sc.parallelize(Array(new DenseVector(Array(1.1, 1.8)),
+      new DenseVector(Array(-3.3, -3.6))), 2)
 
     val fun1 = new SmoothHuber(x0, 0.2)
     val Value(Some(f1), Some(g1)) = fun1(x, Mode(true, true))
@@ -90,10 +92,10 @@ class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext {
 
   test("The SmoothLogLLogistic implementation should return the expected value and gradient") {
 
-    val y = sc.parallelize(Array(Vectors.dense(1.0, 0.0).toDense,
-      Vectors.dense(0.0, 1.0, 1.0).toDense), 2)
-    val mu = sc.parallelize(Array(Vectors.dense(0.1, -0.2).toDense,
-      Vectors.dense(0.3, -0.4, 0.0).toDense), 2)
+    val y = sc.parallelize(Array(new DenseVector(Array(1.0, 0.0)),
+      new DenseVector(Array(0.0, 1.0, 1.0))), 2)
+    val mu = sc.parallelize(Array(new DenseVector(Array(0.1, -0.2)),
+      new DenseVector(Array(0.3, -0.4, 0.0))), 2)
     val fun = new SmoothLogLLogistic(y)
 
     val Value(Some(f), Some(g)) = fun(mu, Mode(true, true))
@@ -115,23 +117,23 @@ class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext {
 
   test("The SmoothDual implementation should return the expected value and gradient") {
 
-    val c = sc.parallelize(Array(Vectors.dense(1.0, -2.2).toDense,
-      Vectors.dense(3.4, -4.6, 5.8).toDense), 2)
+    val c = sc.parallelize(Array(new DenseVector(Array(1.0, -2.2)),
+      new DenseVector(Array(3.4, -4.6, 5.8))), 2)
     val objectiveF = new ProxShiftRPlus(c)
     val mu = 0.2
-    val x0 = sc.parallelize(Array(Vectors.dense(2.0, -1.2).toDense,
-      Vectors.dense(0.4, -1.6, 2.8).toDense), 2)
-    val ATz = sc.parallelize(Array(Vectors.dense(12.0, -11.2).toDense,
-      Vectors.dense(10.4, -11.6, 12.8).toDense), 2)
+    val x0 = sc.parallelize(Array(new DenseVector(Array(2.0, -1.2)),
+      new DenseVector(Array(0.4, -1.6, 2.8))), 2)
+    val ATz = sc.parallelize(Array(new DenseVector(Array(12.0, -11.2)),
+      new DenseVector(Array(10.4, -11.6, 12.8))), 2)
     val fun = new SmoothDual(objectiveF, mu, x0)
 
     val Value(Some(f), Some(g)) = fun(ATz, Mode(true, true))
 
-    val expectedOffsetCenter = sc.parallelize(Array(Vectors.dense(mu * 12.0 + 2.0,
-      mu * -11.2 + -1.2).toDense,
-      Vectors.dense(mu * 10.4 + 0.4,
+    val expectedOffsetCenter = sc.parallelize(Array(new DenseVector(Array(mu * 12.0 + 2.0,
+      mu * -11.2 + -1.2)),
+      new DenseVector(Array(mu * 10.4 + 0.4,
         mu * -11.6 + -1.6,
-        mu * 12.8 + 2.8).toDense), 2)
+        mu * 12.8 + 2.8))), 2)
     val ProxValue(Some(expectedProxF), Some(expectedProxMinimizer)) =
       objectiveF(expectedOffsetCenter, mu, ProxMode(true, true))
 
@@ -147,11 +149,11 @@ class SmoothFunctionSuite extends FunSuite with MLlibTestSparkContext {
 
   test("The SmoothCombine implementation should return the expected value and gradient") {
 
-    val x0 = sc.parallelize(Array(Vectors.dense(2.0, -1.2).toDense,
-      Vectors.dense(0.4, -1.6, 2.8).toDense), 2)
+    val x0 = sc.parallelize(Array(new DenseVector(Array(2.0, -1.2)),
+      new DenseVector(Array(0.4, -1.6, 2.8))), 2)
     val objectiveF = new SmoothQuad(x0)
-    val x = (sc.parallelize(Array(Vectors.dense(9.0, 10.1).toDense,
-      Vectors.dense(11.2, 12.3, 13.4).toDense), 2),
+    val x = (sc.parallelize(Array(new DenseVector(Array(9.0, 10.1)),
+      new DenseVector(Array(11.2, 12.3, 13.4))), 2),
       88.1)
     val fun = new SmoothCombine(objectiveF)
 

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SolverL1RLSSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SolverL1RLSSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.mllib.optimization.tfocs
 
 import org.scalatest.FunSuite
 
-import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.linalg.{ DenseVector, Vectors }
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 
@@ -59,7 +59,7 @@ class SolverL1RLSSuite extends FunSuite with MLlibTestSparkContext {
       Vectors.dense(-0.2341, -0.5792, 0.3272, -0.7748, 0.6396, -0.7910, -0.6239, -0.6901, 0.0249,
         0.6624)), 2)
     val b = sc.parallelize(Array(0.1614, -0.1662, 0.4224, -0.2945, -0.3866), 2).glom.map(
-      Vectors.dense(_).toDense)
+      new DenseVector(_))
     val lambda = 0.0298
     val x0 = Vectors.zeros(10).toDense
 

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SolverSLPSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SolverSLPSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.mllib.optimization.tfocs
 import org.scalatest.FunSuite
 import scala.io.Source
 
-import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.linalg.{ DenseVector, Vectors }
 import org.apache.spark.mllib.optimization.tfocs.DVectorFunctions._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
@@ -56,14 +56,14 @@ class SolverSLPSuite extends FunSuite with MLlibTestSparkContext {
       Vectors.sparse(5, Seq((2, 0.179885783103202))), Vectors.zeros(5), Vectors.zeros(5),
       Vectors.zeros(5), Vectors.zeros(5), Vectors.sparse(5, Seq((1, 0.014792694748719))),
       Vectors.zeros(5), Vectors.sparse(5, Seq((3, 0.244326895623829)))), 2)
-    var b = Vectors.dense(0, 7.127414296861894, 1.781441255102280, 2.497425876822379,
-      2.186136752456199).toDense
+    var b = new DenseVector(Array(0, 7.127414296861894, 1.781441255102280, 2.497425876822379,
+      2.186136752456199))
     val c = sc.parallelize(Array(-1.078275146772097, -0.368208440839284, 0.680376092886272,
       0.256371934668609, 1.691983132986665, 0.059837119884475, -0.221648385883038,
       -0.298134575377277, -1.913199010346937, 0.745084172661387), 2).glom.map(
-      Vectors.dense(_).toDense)
+      new DenseVector(_))
     val mu = 0.01
-    val x0 = sc.parallelize(Array.fill(10)(0.0), 2).glom.map(Vectors.dense(_).toDense)
+    val x0 = sc.parallelize(Array.fill(10)(0.0), 2).glom.map(new DenseVector(_))
     val z0 = Vectors.zeros(5).toDense
     val dualTolCheckInterval = 1 // Matlab tfocs checks for convergence on every iteration.
 

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpaceSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/VectorSpaceSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.mllib.optimization.tfocs
 
 import org.scalatest.FunSuite
 
-import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.linalg.{ DenseVector, Vectors }
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.optimization.tfocs.DVectorFunctions._
 import org.apache.spark.mllib.optimization.tfocs.VectorSpace._
@@ -31,17 +31,17 @@ class VectorSpaceSuite extends FunSuite with MLlibTestSparkContext {
 
   test("DenseVectorSpace.combine is implemented properly") {
     val alpha = 1.1
-    val a = Vectors.dense(2.0, 3.0).toDense
+    val a = new DenseVector(Array(2.0, 3.0))
     val beta = 4.0
-    val b = Vectors.dense(5.0, 6.0).toDense
+    val b = new DenseVector(Array(5.0, 6.0))
     val expectedCombination = Vectors.dense(1.1 * 2.0 + 4.0 * 5.0, 1.1 * 3.0 + 4.0 * 6.0)
     assert(DenseVectorSpace.combine(alpha, a, beta, b) == expectedCombination,
       "DenseVectorSpace.combine should return the correct result.")
   }
 
   test("DenseVectorSpace.dot is implemented properly") {
-    val a = Vectors.dense(2.0, 3.0).toDense
-    val b = Vectors.dense(5.0, 6.0).toDense
+    val a = new DenseVector(Array(2.0, 3.0))
+    val b = new DenseVector(Array(5.0, 6.0))
     val expectedDot = 2.0 * 5.0 + 3.0 * 6.0
     assert(DenseVectorSpace.dot(a, b) == expectedDot,
       "DenseVectorSpace.dot should return the correct result.")
@@ -49,9 +49,9 @@ class VectorSpaceSuite extends FunSuite with MLlibTestSparkContext {
 
   test("DVectorSpace.combine is implemented properly") {
     val alpha = 1.1
-    val a = sc.parallelize(Array(Vectors.dense(2.0, 3.0).toDense, Vectors.dense(4.0).toDense), 2)
+    val a = sc.parallelize(Array(new DenseVector(Array(2.0, 3.0)), new DenseVector(Array(4.0))), 2)
     val beta = 4.0
-    val b = sc.parallelize(Array(Vectors.dense(5.0, 6.0).toDense, Vectors.dense(7.0).toDense), 2)
+    val b = sc.parallelize(Array(new DenseVector(Array(5.0, 6.0)), new DenseVector(Array(7.0))), 2)
     val combination = DVectorSpace.combine(alpha, a, beta, b)
     val expectedCombination =
       Vectors.dense(1.1 * 2.0 + 4.0 * 5.0, 1.1 * 3.0 + 4.0 * 6.0, 1.1 * 4.0 + 4.0 * 7.0)
@@ -60,8 +60,8 @@ class VectorSpaceSuite extends FunSuite with MLlibTestSparkContext {
   }
 
   test("DVectorSpace.dot is implemented properly") {
-    val a = sc.parallelize(Array(Vectors.dense(2.0, 3.0).toDense, Vectors.dense(4.0).toDense), 2)
-    val b = sc.parallelize(Array(Vectors.dense(5.0, 6.0).toDense, Vectors.dense(7.0).toDense), 2)
+    val a = sc.parallelize(Array(new DenseVector(Array(2.0, 3.0)), new DenseVector(Array(4.0))), 2)
+    val b = sc.parallelize(Array(new DenseVector(Array(5.0, 6.0)), new DenseVector(Array(7.0))), 2)
     val expectedDot = 2.0 * 5.0 + 3.0 * 6.0 + 4.0 * 7.0
     assert(DVectorSpace.dot(a, b) == expectedDot,
       "DVectorSpace.dot should return the correct result.")
@@ -69,11 +69,11 @@ class VectorSpaceSuite extends FunSuite with MLlibTestSparkContext {
 
   test("DVectorDoubleSpace.combine is implemented properly") {
     val alpha = 1.1
-    val a = (sc.parallelize(Array(Vectors.dense(2.0, 3.0).toDense, Vectors.dense(4.0).toDense), 2),
-      9.9)
+    val a = (sc.parallelize(Array(new DenseVector(Array(2.0, 3.0)), new DenseVector(Array(4.0))),
+      2), 9.9)
     val beta = 4.0
-    val b = (sc.parallelize(Array(Vectors.dense(5.0, 6.0).toDense, Vectors.dense(7.0).toDense), 2),
-      11.11)
+    val b = (sc.parallelize(Array(new DenseVector(Array(5.0, 6.0)), new DenseVector(Array(7.0))),
+      2), 11.11)
     val combination = DVectorDoubleSpace.combine(alpha, a, beta, b)
     val expectedCombination =
       (Vectors.dense(1.1 * 2.0 + 4.0 * 5.0, 1.1 * 3.0 + 4.0 * 6.0, 1.1 * 4.0 + 4.0 * 7.0),
@@ -85,10 +85,10 @@ class VectorSpaceSuite extends FunSuite with MLlibTestSparkContext {
   }
 
   test("DVectorDoubleSpace.dot is implemented properly") {
-    val a = (sc.parallelize(Array(Vectors.dense(2.0, 3.0).toDense, Vectors.dense(4.0).toDense), 2),
-      9.9)
-    val b = (sc.parallelize(Array(Vectors.dense(5.0, 6.0).toDense, Vectors.dense(7.0).toDense), 2),
-      11.11)
+    val a = (sc.parallelize(Array(new DenseVector(Array(2.0, 3.0)), new DenseVector(Array(4.0))),
+      2), 9.9)
+    val b = (sc.parallelize(Array(new DenseVector(Array(5.0, 6.0)), new DenseVector(Array(7.0))),
+      2), 11.11)
     val expectedDot = 2.0 * 5.0 + 3.0 * 6.0 + 4.0 * 7.0 + 9.9 * 11.11
     assert(DVectorDoubleSpace.dot(a, b) == expectedDot,
       "DVectorVectorSpace.dot should return the correct result.")


### PR DESCRIPTION
- Vectors.dense(_).toDense -> new DenseVector(_)
- remove unnecessary '_ match'
