### PR TITLE
Do not require starting x0 and z0 in solver helpers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To solve the smoothed standard form linear program:
 
 ## Software Architecture Overview
 
-The primary types used in the Spark TFOCS library are:
+The primary types used in the Spark TFOCS library are as follows:
 
 * `DenseVector` A wrapper around `Array[Double]` with support for vector operations. (Imported
   from `org.apache.spark.mllib.linalg`)
@@ -102,7 +102,7 @@ The primary types used in the Spark TFOCS library are:
   represents a row of the matrix. More information is available in
   `org.apache.spark.mllib.optimization.tfocs.VectorSpace`.
 
-The primary abstractions in the Spark TFOCS library are:
+The primary abstractions of the Spark TFOCS library are as follows:
 
 * `VectorSpace` A basic vector space interface with support for computing linear combinations and
   dot products. This abstraction supports local computation and also distributed computation using
@@ -114,6 +114,19 @@ The primary abstractions in the Spark TFOCS library are:
 
 * `ProxCapableFunction` An interface for evaluating a function and computing the minimizing value
   of its proximity operator.
+
+The following naming conventions are used in the Spark TFOCS library:
+
+* To the extent possible, classes and functions are given the same names as the corresponding
+  implementation in Matlab TFOCS.
+
+* `VectorSpace` implementations are placed in the `vs` namespace. For example the `VectorSpace` for
+  `DVector` vectors is named `vs.dvector`.
+
+* Function implementations (implementations of `LinearOperator`, `SmoothFunction`, and
+  `ProxCapableFunction`) are placed in the `fs` (function space) namespace, and are specifically
+  named according to their input and output types. For example, functions with input type `DVector`
+  and output type `Double` are placed in the `fs.dvector.double` namespace.
 
 ## TODOs
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,10 @@ linear regression):
     val b = sc.parallelize(Array(0.1614, -0.1662, 0.4224, -0.2945, -0.3866), 2).glom.map(
       new DenseVector(_))
     val lambda = 0.0298
-    val x0 = Vectors.zeros(10).toDense
 
-    SolverL1RLS.run(A, b, lambda, x0)
+    SolverL1RLS.run(A, b, lambda)
 
-Alternatively, the above optimization may be executed using TFOCS optimizer directly rather than
+Alternatively, the above optimization may be executed using the TFOCS optimizer directly rather than
 with the `SolverL1RLS` helper implementation:
 
     import org.apache.spark.mllib.optimization.tfocs.fs.dvector.double._
@@ -51,6 +50,7 @@ with the `SolverL1RLS` helper implementation:
     import org.apache.spark.mllib.optimization.tfocs.TFOCS
     import org.apache.spark.mllib.optimization.tfocs.vs.dvector._
     import org.apache.spark.mllib.optimization.tfocs.vs.vector._
+    val x0 = Vectors.zeros(10).toDense
 
     TFOCS.optimize(new SmoothQuad(b), new LinopMatrix(A), new ProxL1(lambda), x0)
 
@@ -75,10 +75,8 @@ To solve the smoothed standard form linear program:
       -0.298134575377277, -1.913199010346937, 0.745084172661387), 2).glom.map(
       new DenseVector(_))
     val mu = 1e-2
-    val x0 = sc.parallelize(Array.fill(10)(0.0), 2).glom.map(new DenseVector(_))
-    val z0 = Vectors.zeros(5).toDense
 
-    SolverSLP.run(c, A, b, mu, x0, z0)
+    SolverSLP.run(c, A, b, mu)
 
 ## Solvers
 

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SolverL1RLS.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SolverL1RLS.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.mllib.optimization.tfocs
 
-import org.apache.spark.mllib.linalg.DenseVector
+import org.apache.spark.mllib.linalg.{ DenseVector, Vectors }
 import org.apache.spark.mllib.optimization.tfocs.fs.dvector.double._
 import org.apache.spark.mllib.optimization.tfocs.fs.vector.double._
 import org.apache.spark.mllib.optimization.tfocs.fs.vector.dvector._
@@ -36,7 +36,7 @@ object SolverL1RLS {
    * @param A The design matrix, represented as a DMatrix.
    * @param b The observed values, represented as a DVector.
    * @param lambda The regularization term.
-   * @param x0 Initial value of 'x'.
+   * @param x0 Initial value of 'x'. A default value will be used if not provided.
    *
    * @return A tuple containing two elements. The first element is a vector containing the optimized
    *         'x' value. The second element contains the objective function history.
@@ -55,9 +55,15 @@ object SolverL1RLS {
    * NOTE In matlab tfocs this functionality is implemented in solver_L1RLS.m.
    * @see [[https://github.com/cvxr/TFOCS/blob/master/solver_L1RLS.m]]
    */
-  def run(A: DMatrix, b: DVector, lambda: Double, x0: DenseVector): (DenseVector, Array[Double]) = {
+  def run(A: DMatrix,
+    b: DVector,
+    lambda: Double,
+    x0: Option[DenseVector] = None): (DenseVector, Array[Double]) = {
     val (x, TFOCS.OptimizationData(lossHistory, _, _)) =
-      TFOCS.optimize(new SmoothQuad(b), new LinopMatrix(A), new ProxL1(lambda), x0)
+      TFOCS.optimize(new SmoothQuad(b),
+        new LinopMatrix(A),
+        new ProxL1(lambda),
+        x0.getOrElse(Vectors.zeros(A.first().size).toDense))
     (x, lossHistory)
   }
 }

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SolverSLP.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/SolverSLP.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.mllib.optimization.tfocs
 
-import org.apache.spark.mllib.linalg.{ BLAS, DenseVector }
+import org.apache.spark.mllib.linalg.{ BLAS, DenseVector, Vectors }
+import org.apache.spark.mllib.optimization.tfocs.DVectorFunctions._
 import org.apache.spark.mllib.optimization.tfocs.VectorSpace._
 import org.apache.spark.mllib.optimization.tfocs.fs.dvector.double._
 import org.apache.spark.mllib.optimization.tfocs.fs.dvectordouble.vector._
@@ -38,8 +39,9 @@ object SolverSLP {
    *        represented as a distributed matrix, DMatrix. See note below.
    * @param b Constraint coefficient vector.
    * @param mu Smoothing parameter.
-   * @param x0 Starting x value. Represented as a distributed vector, DVector. See note below.
-   * @param z0 Starting dual (z) value.
+   * @param x0 Starting x value. Represented as a distributed vector, DVector. See note below. A
+   *        default value will be used if not provided.
+   * @param z0 Starting dual (z) value. A default value will be used if not provided.
    * @param numContinuations The maximum number of continuations to use in the TFOCS_SCD
    *        implementation.
    * @param tol The convergence tolerance threshold.
@@ -72,8 +74,8 @@ object SolverSLP {
     A: DMatrix,
     b: DenseVector,
     mu: Double,
-    x0: DVector,
-    z0: DenseVector,
+    x0: Option[DVector] = None,
+    z0: Option[DenseVector] = None,
     numContinuations: Int = 10,
     tol: Double = 1e-4,
     initialTol: Double = 1e-3,
@@ -85,8 +87,8 @@ object SolverSLP {
       new LinopMatrixAdjoint(A, minusB),
       new ProxZero(),
       mu,
-      x0,
-      z0,
+      x0.getOrElse(c.mapElements(_ => 0.0)),
+      z0.getOrElse(Vectors.zeros(b.size).toDense),
       numContinuations,
       tol,
       initialTol,

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLASSO.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLASSO.scala
@@ -80,8 +80,7 @@ object TestLASSO {
     val lambda = 2 * sigma * math.sqrt(2 * math.log(n))
 
     // Solve the lasso problem using SolverL1RLS, finding the estimated x vector 'estimatedX'.
-    val x0 = Vectors.zeros(n).toDense
-    val (estimatedX, _) = SolverL1RLS.run(A, b, lambda, x0)
+    val (estimatedX, _) = SolverL1RLS.run(A, b, lambda)
     println("estimatedX: " + estimatedX.values.mkString(", "))
 
     sc.stop()

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLinearProgram.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestLinearProgram.scala
@@ -19,7 +19,7 @@ package org.apache.spark.mllib.optimization.tfocs.examples
 
 import scala.util.Random
 
-import org.apache.spark.mllib.linalg.{ DenseVector, Vectors }
+import org.apache.spark.mllib.linalg.DenseVector
 import org.apache.spark.mllib.optimization.tfocs.DVectorFunctions._
 import org.apache.spark.mllib.optimization.tfocs.SolverSLP
 import org.apache.spark.mllib.optimization.tfocs.fs.dvector.vector.LinopMatrixAdjoint
@@ -81,11 +81,9 @@ object TestLinearProgram {
     val b = new LinopMatrixAdjoint(A)(x)
 
     val mu = 1e-2
-    val x0 = sc.parallelize(new Array[Double](n)).glom.map(new DenseVector(_))
-    val z0 = Vectors.zeros(m).toDense
 
     // Solve the linear program using SolverSLP, finding the optimal x vector 'optimalX'.
-    val (optimalX, _) = SolverSLP.run(c, A, b, mu, x0, z0)
+    val (optimalX, _) = SolverSLP.run(c, A, b, mu)
     println("optimalX: " + optimalX.collectElements.mkString(", "))
 
     sc.stop()

--- a/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestMPSLinearProgram.scala
+++ b/src/main/scala/org/apache/spark/mllib/optimization/tfocs/examples/TestMPSLinearProgram.scala
@@ -63,11 +63,9 @@ object TestMPSLinearProgram {
     val n = converter.getStandardN
 
     val mu = 1e-2
-    val x0 = sc.parallelize(new Array[Double](n)).glom.map(new DenseVector(_))
-    val z0 = Vectors.zeros(b.size).toDense
 
     // Solve the linear program using SolverSLP, finding the optimal x vector 'optimalX'.
-    val (optimalX, _) = SolverSLP.run(c, A, b, mu, x0, z0)
+    val (optimalX, _) = SolverSLP.run(c, A, b, mu)
     println("optimalX: " + optimalX.collectElements.mkString(", "))
 
     sc.stop()

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SolverL1RLSSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SolverL1RLSSuite.scala
@@ -61,9 +61,8 @@ class SolverL1RLSSuite extends FunSuite with MLlibTestSparkContext {
     val b = sc.parallelize(Array(0.1614, -0.1662, 0.4224, -0.2945, -0.3866), 2).glom.map(
       new DenseVector(_))
     val lambda = 0.0298
-    val x0 = Vectors.zeros(10).toDense
 
-    val (x, lossHistory) = SolverL1RLS.run(A, b, lambda, x0)
+    val (x, lossHistory) = SolverL1RLS.run(A, b, lambda)
 
     val expectedX = Vectors.dense(-0.049755786974910, 0, 0.076369527414210, 0, 0, 0, 0,
       0.111550837996771, -0.314626347477663, -0.503782689620966)

--- a/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SolverSLPSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/optimization/tfocs/SolverSLPSuite.scala
@@ -64,11 +64,10 @@ class SolverSLPSuite extends FunSuite with MLlibTestSparkContext {
       -0.298134575377277, -1.913199010346937, 0.745084172661387), 2).glom.map(
       new DenseVector(_))
     val mu = 1e-2
-    val x0 = sc.parallelize(Array.fill(10)(0.0), 2).glom.map(new DenseVector(_))
-    val z0 = Vectors.zeros(5).toDense
     val dualTolCheckInterval = 1 // Matlab tfocs checks for convergence on every iteration.
 
-    val (x, lossHistory) = SolverSLP.run(c, A, b, mu, x0, z0, 10, 1e-3, 1e-2, dualTolCheckInterval)
+    val (x, lossHistory) =
+      SolverSLP.run(c, A, b, mu, None, None, 10, 1e-3, 1e-2, dualTolCheckInterval)
 
     val expectedX = Vectors.dense(2048.722778866985, 0, 0, 0, 0, 0, 421.131933177772,
       546.803269626285, 3635.078119659181, 10.514625914138)


### PR DESCRIPTION
The SolverL1RLS and SolverSLP helpers require that an initial x iterate be provided and that an initial z (dual) iterate be provided in the case of SolverSLP. This patch adds support for default initial x and z iterates. The caller is no longer required to provide them.
